### PR TITLE
Add repository README and root Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+SUBDIRS := htable minheap nlmon syslog2 timeutil uevent
+COV_DIRS := minheap nlmon syslog2 timeutil
+
+.PHONY: test coverage clean
+
+# Run tests in all modules
+test:
+	@set -e; for d in $(SUBDIRS); do \
+		printf '\n==> $$d\n'; \
+		if [ "$$d" = "uevent" ]; then \
+			$(MAKE) -C $$d check; \
+		else \
+			$(MAKE) -C $$d test; \
+		fi; \
+	done
+
+# Run coverage where supported
+coverage:
+	@set -e; for d in $(COV_DIRS); do \
+		printf '\n==> $$d (coverage)\n'; \
+		$(MAKE) -C $$d coverage; \
+	done
+
+clean:
+	@for d in $(SUBDIRS); do $(MAKE) -C $$d clean; done

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# C Module Collection
+
+This repository contains several small C libraries and utilities. Each module lives in its own directory with a standalone `Makefile` and unit tests.
+
+## Modules
+
+- **htable** – simple hash table implementation.
+- **minheap** – binary min-heap container.
+- **nlmon** – netlink monitor used for tracking network events.
+- **syslog2** – lightweight asynchronous logging helper.
+- **timeutil** – helper routines for measuring time and pausing execution.
+- **uevent** – event loop implementation built on `epoll`.
+
+## Running Tests
+
+Every module directory exposes a `test` target:
+
+```sh
+cd <module>
+make test
+```
+
+Some modules (minheap, nlmon, syslog2 and timeutil) also provide a `coverage` target that recompiles with GCOV flags and prints a short coverage report:
+
+```sh
+cd <module>
+make coverage
+```
+
+The `uevent` module offers a `check` target which runs both regular and robust tests.
+
+## Root Makefile
+
+The optional Makefile in the repository root aggregates common actions:
+
+- `make test` – run tests for all modules.
+- `make coverage` – run coverage for modules that support it.
+- `make clean` – remove build artefacts in all modules.
+
+Use it as a convenience wrapper instead of invoking `make` in each subdirectory.


### PR DESCRIPTION
## Summary
- document each module in a new README
- provide instructions for running module tests and coverage
- add an aggregate Makefile with convenience targets

## Testing
- `make test` *(fails: no rule to make target '../syslog.c')*
- `make coverage` *(fails: missing ../syslog.c for minheap)*

------
https://chatgpt.com/codex/tasks/task_e_686a57b9e55483309871881cfac686a5