### PR TITLE
Add filter-based interface monitoring to nlmon

### DIFF
--- a/nlmon/nlmon.h
+++ b/nlmon/nlmon.h
@@ -2,6 +2,7 @@
 #define NL_MON_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 // Заглушка для uevent_t, предполагаем, что определена где-то в коде
 typedef struct uevent_s uevent_t;
@@ -16,6 +17,23 @@ typedef struct {
   pause_fn_t tu_pause_end;
 } nl_cb_arg_t;
 
+typedef struct {
+    const char **ifnames;  // NULL-terminated array, may be NULL/empty
+    uint32_t events;       // bit mask of monitored events
+    void (*cb)(const char *ifname, uint32_t events, void *arg);
+    void *arg;
+} nlmon_filter_t;
+
+#ifdef TESTRUN
+typedef struct nlmon_test_msg {
+  char *buf;
+  size_t len;
+} nlmon_test_msg_t;
+#endif
+
+#define NLMON_EVENT_LINK_UP 0x1
+#define NLMON_EVENT_LINK_DOWN 0x2
+
 // Инициализация Netlink-мониторинга
 int init_netlink_monitor();
 
@@ -23,6 +41,7 @@ int init_netlink_monitor();
 void deinit_netlink_monitor(int fd);
 
 // Callback для обработки Netlink-событий
-void nl_handler_cb(uevent_t *ev, int fd, short events, void *arg);
+void nl_handler_cb(uevent_t *ev, int fd, short events, nlmon_filter_t *filters,
+                   size_t filter_cnt);
 
 #endif // NL_MON_H


### PR DESCRIPTION
## Summary
- add `nlmon_filter_t` and event flags
- extend `nl_handler_cb` to iterate over filters
- update nlmon_main to use new API
- rewrite tests for new filter API including multiple filters

## Testing
- `make -C timeutil` *(passes)*
- `make -C syslog2` *(passes)*
- `make -C nlmon test TESTRUN=1` *(passes)*


------
https://chatgpt.com/codex/tasks/task_e_686a57b99198833093111a24b2542d2a