### PR TITLE
Expand syslog2 test coverage

### DIFF
--- a/syslog2/Makefile
+++ b/syslog2/Makefile
@@ -60,7 +60,7 @@ clean:
 	rm -f *.o *.gcov *.gcno *.gcda $(LIBNAME) test main callgrind.out
 
 coverage: clean
-	$(MAKE) CFLAGS="$(COV_CFLAGS)" LDFLAGS="$(COV_LDFLAGS)" LIBS="$(LIBS)" test
+	$(MAKE) DEBUG=1 CFLAGS="$(COV_CFLAGS)" LDFLAGS="$(COV_LDFLAGS)" LIBS="$(LIBS)" test
 	@echo "=== Coverage report (gcov): ==="
 	@gcov syslog2.c | grep -A10 "File 'syslog2.c'"
 	@echo "=== Coverage report (summary): ==="

--- a/syslog2/test.c
+++ b/syslog2/test.c
@@ -1,22 +1,47 @@
 // test.c
 #include "syslog2.h"
+#include <pthread.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 int main(void) {
+  char buf[16];
+
   setup_syslog2("test_syslog2", LOG_DEBUG, false);
+
+  /* Check that log mask filtering works */
+  setlogmask2(LOG_UPTO(LOG_INFO));
+  syslog2(LOG_DEBUG, "This debug should be filtered");
+  setlogmask2(LOG_UPTO(LOG_DEBUG));
 
   syslog2(LOG_INFO, "Starting test");
   syslog2(LOG_DEBUG, "Debug message: %d", 42);
   syslog2_nonl(LOG_WARNING, "Warning message without newline");
   syslog2(LOG_WARNING, " - continued");
 
-  PTHREAD_SET_NAME;
+  /* Set explicit thread name and verify */
+  inline_pthread_set_name("syslog2_test", strlen("syslog2_test"));
+  pthread_getname_np(pthread_self(), buf, sizeof(buf));
+  syslog2(LOG_INFO, "Thread name: %s", buf);
 
-  // Simulate function tracking
+  /* Also test the macro version */
+  PTHREAD_SET_NAME;
+  pthread_getname_np(pthread_self(), buf, sizeof(buf));
+  syslog2(LOG_INFO, "Thread name macro: %s", buf);
+
+  /* Simulate function tracking */
   SET_CURRENT_FUNCTION();
   syslog2(LOG_INFO, "Function tracking test");
+
+  /* printf style */
+  syslog2_printf(LOG_NOTICE, "printf test\n");
+
+  /* debug output */
+  debug("debug output\n");
+
+  print_last_functions();
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- extend `syslog2/test.c` with more functional tests
- compile coverage build with `DEBUG=1` so `debug()` is executed

## Testing
- `make coverage` in syslog2

------
https://chatgpt.com/codex/tasks/task_e_686a57b794b883309b1dad54aaeb1f8a