### PR TITLE
Add coverage build to htable and uevent

### DIFF
--- a/htable/Makefile
+++ b/htable/Makefile
@@ -6,6 +6,26 @@ LIBNAME = libhtable.a
 OBJ = htable.o
 TEST_OBJ = test.o
 MAIN_OBJ = main.o
+LDFLAGS = -L.
+LIBS = -lhtable
+
+COV_CFLAGS = $(CFLAGS) -O0 -g -fprofile-arcs -ftest-coverage
+COV_LDFLAGS = $(LDFLAGS) -fprofile-arcs -ftest-coverage
+
+ifeq ($(DEBUG),1)
+  CFLAGS += -O0 -DDEBUG=1 -g
+  COV_CFLAGS += -O0 -DDEBUG=1 -g
+endif
+
+ifeq ($(TESTRUN),1)
+  CFLAGS += -DTESTRUN=1
+  COV_CFLAGS += -DTESTRUN=1
+endif
+
+ifeq ($(MAKECMDGOALS),coverage)
+  CFLAGS += -DTESTRUN=1
+  COV_CFLAGS += -DTESTRUN=1
+endif
 
 all: $(LIBNAME) main test
 
@@ -16,10 +36,10 @@ htable.o: htable.c htable.h
 	$(CC) $(CFLAGS) -c htable.c
 
 main: $(MAIN_OBJ) $(LIBNAME)
-	$(CC) $(CFLAGS) $(MAIN_OBJ) -L. -lhtable -o main
-
+	$(CC) $(CFLAGS) $(MAIN_OBJ) -o main $(LDFLAGS) $(LIBS)
+		
 test: $(TEST_OBJ) $(LIBNAME)
-	$(CC) $(CFLAGS) $(TEST_OBJ) -L. -lhtable -o test
+	$(CC) $(CFLAGS) $(TEST_OBJ) -o test $(LDFLAGS) $(LIBS)
 	./test
 
 main.o: main.c htable.h
@@ -40,4 +60,11 @@ leak: test
 clean:
 	rm -f *.o *.gcov *.gcno *.gcda $(LIBNAME) main test callgrind.out
 
-.PHONY: all clean perf
+coverage: clean
+	$(MAKE) CFLAGS="$(COV_CFLAGS)" LDFLAGS="$(COV_LDFLAGS)" LIBS="$(LIBS)" test
+	@echo "=== Coverage report (gcov): ==="
+	@gcov htable.c | grep -A10 "File 'htable.c'"
+	@echo "=== Coverage report (summary): ==="
+	@gcov -b htable.c | grep -E 'Lines executed|Branches executed'
+
+.PHONY: all clean perf leak coverage test main

--- a/uevent/Makefile
+++ b/uevent/Makefile
@@ -23,6 +23,9 @@ LDFLAGS_TEST = -ltsan
 LDFLAGS = -lpthread
 PERF_LDFLAGS = $(LDFLAGS) -levent -luv
 
+COV_CFLAGS = $(CFLAGS) -O0 -g -fprofile-arcs -ftest-coverage
+COV_LDFLAGS = $(LDFLAGS) -fprofile-arcs -ftest-coverage
+
 # Имена целей
 MAIN = main_bin
 TEST_BIN = test_bin
@@ -110,4 +113,11 @@ $(LIB): $(OBJS)
 clean:
 	rm -f $(MAIN) $(TEST_BIN) $(ROBUST_TEST_BIN) $(PERF) $(LIB) callgrind.out *.o ../syslog2/*.o ../timeutil/*.o ../minheap/*.o ../*.o
 
-.PHONY: all test robust_test check clean
+coverage: clean
+	$(MAKE) CFLAGS="$(COV_CFLAGS)" LDFLAGS="$(COV_LDFLAGS)" test
+	@echo "=== Coverage report (gcov): ==="
+	@gcov uevent.c | grep -A10 "File 'uevent.c'"
+	@echo "=== Coverage report (summary): ==="
+	@gcov -b uevent.c | grep -E 'Lines executed|Branches executed'
+
+.PHONY: all test robust_test check clean coverage


### PR DESCRIPTION
## Summary
- add coverage variables and rule to `htable/Makefile`
- add coverage variables and rule to `uevent/Makefile`

## Testing
- `make -C htable coverage`
- `make -C uevent coverage` *(produces large tsan logs)*

------
https://chatgpt.com/codex/tasks/task_e_686a5752f33c8330b4808a719e08ef3e