### PR TITLE
Add thorough timeutil unit tests

### DIFF
--- a/timeutil/timeutil.h
+++ b/timeutil/timeutil.h
@@ -39,6 +39,11 @@ int msleep(uint64_t ms);
 void atomic_ts_load(atomic_timespec_t *src, struct timespec *dest);
 void atomic_ts_store(atomic_timespec_t *dest, struct timespec *src);
 void atomic_ts_cpy(atomic_timespec_t *dest, atomic_timespec_t *src);
+#ifdef TESTRUN
+void tu_trigger_diff_ts_else(void);
+void tu_set_fail_clock(bool v);
+void tu_set_offset_nsec(long ns);
+#endif
 
 static inline int tu_clock_gettime_monotonic_fast(struct timespec *ts) {
   return tu_clock_gettime_fast_internal(ts);


### PR DESCRIPTION
## Summary
- extend `timeutil/test.c` with tests for pause edge cases
- add tests for atomic timespec helpers and monotonic fast ms
- expose test-only helpers in `timeutil.c`/`timeutil.h`
- achieve full coverage via `make coverage`

## Testing
- `make -C timeutil test`
- `make -C timeutil coverage`

------
https://chatgpt.com/codex/tasks/task_e_686a573682288330894f4a30d5223868