### PR TITLE
Update nlmon API

### DIFF
--- a/nlmon/Makefile
+++ b/nlmon/Makefile
@@ -63,7 +63,7 @@ leak: test
 clean:
 	rm -f *.o *.gcov *.gcno *.gcda $(LIBNAME) test main callgrind.out
 
-coverage: clean
+coverage: clean dependencies
 	$(MAKE) CFLAGS="$(COV_CFLAGS)" LDFLAGS="$(COV_LDFLAGS)" LIBS="$(LIBS)" test
 	@echo "=== Coverage report (gcov): ==="
 	@gcov nlmon.c | grep -A10 "File 'nlmon.c'"

--- a/nlmon/nlmon.c
+++ b/nlmon/nlmon.c
@@ -6,6 +6,8 @@
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <net/if.h>
+#include <stdbool.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -16,7 +18,7 @@
 #define DEFROUTE_BUF_SIZE 8192
 
 // Инициализация Netlink-сокета для мониторинга
-int init_netlink_monitor() {
+int init_netlink_monitor(const char *ifnames, uint32_t groups) {
   FUNC_START_DEBUG;
   int fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
   if (fd < 0) {
@@ -26,8 +28,29 @@ int init_netlink_monitor() {
 
   struct sockaddr_nl sa = {
       .nl_family = AF_NETLINK,
-      .nl_groups = RTMGRP_LINK // Мониторим состояние интерфейса
+      .nl_groups = groups ? groups : RTMGRP_LINK
   };
+
+  /* validate interface names if provided */
+  if (ifnames) {
+    char *names = strdup(ifnames);
+    if (!names) {
+      int err = errno;
+      close(fd);
+      return -err;
+    }
+    char *saveptr = NULL;
+    for (char *n = strtok_r(names, ",", &saveptr); n; n = strtok_r(NULL, ",", &saveptr)) {
+      while (*n == ' ') n++;
+      if (*n && if_nametoindex(n) == 0) {
+        syslog2(LOG_ERR, "invalid ifname=%s: %s", n, strerror(errno));
+        free(names);
+        close(fd);
+        return -EINVAL;
+      }
+    }
+    free(names);
+  }
 
   if (bind(fd, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
     int err = errno;
@@ -76,37 +99,53 @@ void nl_handler_cb(uevent_t *ev, int fd, short events, void *arg) {
     return;
   }
 
-  unsigned int ifindex = 0;
-  const char *ifname = NULL;
-  char ifnamebuf[IF_NAMESIZE] = {0};
-  if (cb_arg->ifname) {
-    ifindex = if_nametoindex(cb_arg->ifname);
-    if (ifindex == 0) {
-      syslog2(LOG_ERR, "invalid ifname=%s: %s", cb_arg->ifname, strerror(errno));
+  const char *names[16];
+  size_t names_cnt = 0;
+  if (cb_arg->ifnames) {
+    char *tmp = strdup(cb_arg->ifnames);
+    if (!tmp) {
+      syslog2(LOG_ERR, "strdup failed: %s", strerror(errno));
       return;
     }
-	ifname = cb_arg->ifname;
+    char *saveptr = NULL;
+    for (char *n = strtok_r(tmp, ",", &saveptr); n && names_cnt < 16; n = strtok_r(NULL, ",", &saveptr)) {
+      while (*n == ' ') n++;
+      if (*n)
+        names[names_cnt++] = strdup(n);
+    }
+    free(tmp);
   }
 
+  uint32_t groups = cb_arg->groups ? cb_arg->groups : RTMGRP_LINK;
+
   for (struct nlmsghdr *nh = (struct nlmsghdr *)buf; NLMSG_OK(nh, len); nh = NLMSG_NEXT(nh, len)) {
-    if (nh->nlmsg_type != RTM_NEWLINK) {
+    if ((nh->nlmsg_type == RTM_NEWLINK || nh->nlmsg_type == RTM_DELLINK)) {
+      if (!(groups & RTMGRP_LINK))
+        continue;
+    } else {
       continue;
     }
 
     struct ifinfomsg *ifi = (struct ifinfomsg *)NLMSG_DATA(nh);
-    if (cb_arg->ifname && ifi->ifi_index != (int)ifindex) {
-      continue;
+    char ifnamebuf[IF_NAMESIZE] = {0};
+    const char *ifname = if_indextoname(ifi->ifi_index, ifnamebuf);
+    bool match = (names_cnt == 0);
+    for (size_t i = 0; !match && i < names_cnt; ++i) {
+      if (strcmp(ifname, names[i]) == 0)
+        match = true;
     }
-
-	if(ifindex == 0){
-		ifname = if_indextoname(ifi->ifi_index, ifnamebuf);
-	}
+    if (!match)
+      continue;
 
     if (ifi->ifi_flags & IFF_UP && ifi->ifi_flags & IFF_RUNNING) {
       syslog2(LOG_NOTICE, "idx=%d ifname=%s is UP and RUNNING", ifi->ifi_index, ifname);
-      cb_arg->tu_pause_end(); // Снимаем паузу при восстановлении интерфейса
+      cb_arg->tu_pause_end();
     } else {
       syslog2(LOG_NOTICE, "idx=%d ifname=%s is DOWN flags=0x%x", ifi->ifi_index, ifname, ifi->ifi_flags);
     }
+  }
+
+  for (size_t i = 0; i < names_cnt; ++i) {
+    free((void *)names[i]);
   }
 }

--- a/nlmon/nlmon.h
+++ b/nlmon/nlmon.h
@@ -2,22 +2,24 @@
 #define NL_MON_H
 
 #include <stdint.h>
-
-// Заглушка для uevent_t, предполагаем, что определена где-то в коде
-typedef struct uevent_s uevent_t;
+#include "../uevent/uevent.h"
 
 // Тип указателя на функцию для паузы
 typedef void (*pause_fn_t)(void);
 
 // Структура для аргументов callback'а
 typedef struct {
-  const char *ifname;
+  const char *ifnames;  /* comma separated list of interfaces, NULL for all */
+  uint32_t groups;      /* mask of netlink multicast groups */
   pause_fn_t tu_pause_start;
   pause_fn_t tu_pause_end;
 } nl_cb_arg_t;
 
-// Инициализация Netlink-мониторинга
-int init_netlink_monitor();
+// Инициализация Netlink-мониторинга. ifnames can be NULL and should be either
+// an array of interface names or a comma separated string. groups specifies the
+// netlink multicast groups (e.g. RTMGRP_LINK). If groups is 0 RTMGRP_LINK is
+// used by default.
+int init_netlink_monitor(const char *ifnames, uint32_t groups);
 
 // Деинициализация Netlink-мониторинга
 void deinit_netlink_monitor(int fd);

--- a/nlmon/nlmon_main.c
+++ b/nlmon/nlmon_main.c
@@ -53,7 +53,7 @@ int main(void) {
   };
 
   // Инициализация Netlink-мониторинга
-  int fd = init_netlink_monitor();
+  int fd = init_netlink_monitor(NULL, RTMGRP_LINK);
   if (fd < 0) {
     syslog2(LOG_ERR, "failed to initialize Netlink monitor: %s\n", strerror(-fd));
     return 1;


### PR DESCRIPTION
## Summary
- extend `init_netlink_monitor` API to accept interface list and group mask
- store interface list and mask in `nl_cb_arg_t`
- filter events by interface and groups in `nl_handler_cb`
- update tests to match new API and include real `uevent_t`
- adjust `Makefile` and demo for new function signature

## Testing
- `make coverage`

------
https://chatgpt.com/codex/tasks/task_e_686a574922248330a5d3352785730d37