### PR TITLE
Fix minheap tests to use syslog2 and timeutil

### DIFF
--- a/minheap/Makefile
+++ b/minheap/Makefile
@@ -5,11 +5,11 @@ AR = ar
 ARFLAGS = rcs
 LIBNAME = libminheap.a
 OBJ = minheap.o
-TEST_OBJ = test.o ../syslog.o
+TEST_OBJ = test.o
 MAIN_OBJ = main.o 
 
-LDFLAGS = -L. 
-LIBS = -lminheap 
+LDFLAGS = -L. -L../syslog2 -L../timeutil
+LIBS = -lminheap -lsyslog2 -ltimeutil
 
 COV_CFLAGS = $(CFLAGS) -O0 -g -fprofile-arcs -ftest-coverage
 COV_LDFLAGS = $(LDFLAGS) -fprofile-arcs -ftest-coverage
@@ -29,7 +29,11 @@ ifeq ($(MAKECMDGOALS),coverage)
   COV_CFLAGS += -DTESTRUN=1  
 endif
 
-all: $(LIBNAME) main test
+all: dependencies $(LIBNAME) main test
+
+dependencies:
+	$(MAKE) -C ../timeutil
+	$(MAKE) -C ../syslog2
 
 
 $(LIBNAME): $(OBJ)
@@ -56,9 +60,6 @@ main.o: main.c minheap.h
 test.o: test.c minheap.h
 	$(CC) $(CFLAGS) -c test.c
 
-../syslog.o: ../syslog.c ../syslog.h
-	$(CC) $(CFLAGS) -c ../syslog.c -o ../syslog.o
-
 perf: test
 	@echo "Running valgrind callgrind profiler..."
 	valgrind --tool=callgrind --callgrind-out-file=callgrind.out ./test
@@ -74,6 +75,8 @@ clean:
 
 # ------------------ coverage ------------------
 coverage: clean
+	$(MAKE) -C ../timeutil
+	$(MAKE) -C ../syslog2
 	$(MAKE) CFLAGS="$(COV_CFLAGS)" LDFLAGS="$(COV_LDFLAGS)" LIBS="$(LIBS)" test
 	@echo "=== Coverage report (gcov): ==="
 	@gcov minheap.c | grep -A10 "File 'minheap.c'"
@@ -81,4 +84,4 @@ coverage: clean
 	@gcov -b minheap.c | grep -E 'Lines executed|Branches executed'
 
 
-.PHONY: all clean perf leak
+.PHONY: all clean perf leak coverage test main dependencies

--- a/minheap/test.c
+++ b/minheap/test.c
@@ -1,4 +1,5 @@
-#include "../syslog.h"
+#include "../syslog2/syslog2.h"
+#include "../timeutil/timeutil.h"
 
 #include "heap-inl.h"
 #include "minheap.h"
@@ -57,9 +58,9 @@ typedef struct {
 
 static uint64_t get_current_time_ms(void) {
   struct timespec ts;
-  int ret = clock_gettime_fast(&ts, true);
+  int ret = tu_clock_gettime_monotonic_fast(&ts);
   if (ret != 0) {
-    syslog2(LOG_INFO, "clock_gettime_fast failed: ret=%d", ret);
+    syslog2(LOG_INFO, "tu_clock_gettime_monotonic_fast failed: ret=%d", ret);
     return 0U;
   }
   return (uint64_t)ts.tv_sec * MS_PER_SEC + (uint64_t)(ts.tv_nsec / NS_PER_MS);
@@ -109,16 +110,16 @@ void test_create_malloc_fail() {
 #ifdef TESTRUN
   PRINT_TEST_START("Create heap with malloc failure (negative case)");
   SET_MALLOC(NULL);
-  minheap_t *heap = minheap_create(10);
-  assert(heap == NULL && "minheap_create should fail if malloc fails");
+  minheap_t *heap = mh_create(10);
+  assert(heap == NULL && "mh_create should fail if malloc fails");
   UNSET_MALLOC;
 
   PRINT_TEST_INFO("test if malloc fail on second call");
   mcount = 0;
   SET_MALLOC(test_malloc_fail_second);
-  heap = minheap_create(10);
+  heap = mh_create(10);
   UNSET_MALLOC;
-  assert(heap == NULL && "minheap_create should fail if malloc fail on second call");
+  assert(heap == NULL && "mh_create should fail if malloc fail on second call");
 
   PRINT_TEST_PASSED();
 #endif
@@ -464,7 +465,7 @@ void test_stress_random_operations() {
 // --- Вспомогательная функция для измерения времени ---
 uint64_t get_time_usec() {
   struct timespec ts;
-  clock_gettime_fast(&ts, false);
+  tu_clock_gettime_monotonic_fast(&ts);
   return (uint64_t)ts.tv_sec * 1000000 + ts.tv_nsec / 1000;
 }
 


### PR DESCRIPTION
## Summary
- update minheap test to include syslog2 and timeutil
- replace obsolete `clock_gettime_fast` calls with `tu_clock_gettime_monotonic_fast`
- link minheap against syslog2 and timeutil libraries
- build dependencies before running coverage

## Testing
- `make coverage`

------
https://chatgpt.com/codex/tasks/task_e_686a5752454883309a7b81d65b8f73ec