### PR TITLE
Use syslog2 library for minheap and uevent

### DIFF
--- a/minheap/Makefile
+++ b/minheap/Makefile
@@ -5,11 +5,11 @@ AR = ar
 ARFLAGS = rcs
 LIBNAME = libminheap.a
 OBJ = minheap.o
-TEST_OBJ = test.o ../syslog.o
+TEST_OBJ = test.o
 MAIN_OBJ = main.o 
 
-LDFLAGS = -L. 
-LIBS = -lminheap 
+LDFLAGS = -L. -L../syslog2 -L../timeutil
+LIBS = -lminheap -lsyslog2 -ltimeutil
 
 COV_CFLAGS = $(CFLAGS) -O0 -g -fprofile-arcs -ftest-coverage
 COV_LDFLAGS = $(LDFLAGS) -fprofile-arcs -ftest-coverage
@@ -46,9 +46,12 @@ main: main.o $(LIBNAME)
 #чтобы не удалять бинарник теста
 .PRECIOUS: test
 
-test: $(TEST_OBJ) $(LIBNAME) 
+test: $(TEST_OBJ) $(LIBNAME) ../syslog2/libsyslog2.a
 	$(CC) $(CFLAGS) $(TEST_OBJ) -o test $(LDFLAGS) $(LIBS)
 	./test
+
+../syslog2/libsyslog2.a:
+	$(MAKE) -C ../syslog2
 
 main.o: main.c minheap.h
 	$(CC) $(CFLAGS) -c main.c 
@@ -56,8 +59,6 @@ main.o: main.c minheap.h
 test.o: test.c minheap.h
 	$(CC) $(CFLAGS) -c test.c
 
-../syslog.o: ../syslog.c ../syslog.h
-	$(CC) $(CFLAGS) -c ../syslog.c -o ../syslog.o
 
 perf: test
 	@echo "Running valgrind callgrind profiler..."

--- a/minheap/test.c
+++ b/minheap/test.c
@@ -1,4 +1,4 @@
-#include "../syslog.h"
+#include "../syslog2/syslog2.h"
 
 #include "heap-inl.h"
 #include "minheap.h"
@@ -54,6 +54,10 @@ typedef struct {
 
 #define MS_PER_SEC (1000U)
 #define NS_PER_MS (1000000U)
+
+static inline int clock_gettime_fast(struct timespec *ts, bool raw) {
+  return clock_gettime(raw ? CLOCK_MONOTONIC_RAW : CLOCK_MONOTONIC, ts);
+}
 
 static uint64_t get_current_time_ms(void) {
   struct timespec ts;

--- a/uevent/uevent.c
+++ b/uevent/uevent.c
@@ -19,7 +19,7 @@
 
 #include "../list.h"
 #include "../minheap/minheap.h"
-#include "../syslog.h"
+#include "../syslog2/syslog2.h"
 #include "../timeutil/timeutil.h"
 
 #include "uevent.h"


### PR DESCRIPTION
## Summary
- include syslog2 header in minheap tests and uevent
- fix minheap Makefile to link with syslog2 library and call its build
- provide local wrapper for `clock_gettime_fast`

## Testing
- `make -C timeutil`
- `make -C syslog2`
- `make -C minheap`

------
https://chatgpt.com/codex/tasks/task_e_686a57b5a18c83309ff0bdf9a87431cc