### PR TITLE
Fix coverage link flags

### DIFF
--- a/syslog2/Makefile
+++ b/syslog2/Makefile
@@ -16,7 +16,7 @@ dependencies:
 	$(MAKE) -C ../timeutil LIBS="-ltimeutil"
 
 COV_CFLAGS = $(CFLAGS) -O0 -g -fprofile-arcs -ftest-coverage
-COV_LDFLAGS = $(LDFLAGS) -fprofile-arcs -ftest-coverage
+COV_LDFLAGS = $(LDFLAGS) -fprofile-arcs -ftest-coverage -lgcov
 
 ifeq ($(DEBUG),1)
   CFLAGS += -O0 -DDEBUG=1 -g


### PR DESCRIPTION
## Summary
- link syslog2 coverage build with `-lgcov` so coverage stats show up

## Testing
- `make -C syslog2 coverage`

------
https://chatgpt.com/codex/tasks/task_e_686a5f0e8748833095f01d6abf078983