### PR TITLE
Improve coverage resilience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,17 @@ test:
 
 # Run coverage where supported
 coverage:
-	@set -e; for d in $(COV_DIRS); do \
-		printf '\n==> $$d (coverage)\n'; \
-		$(MAKE) -C $$d coverage; \
-	done
+	@fail=""; \
+	for d in $(COV_DIRS); do \
+	printf '\n==> $$d (coverage)\n'; \
+	if ! $(MAKE) -C $$d coverage; then \
+	fail="$$fail $$d"; \
+	fi; \
+	done; \
+	if [ -n "$$fail" ]; then \
+	echo "Coverage failed in modules:" $$fail; \
+	exit 1; \
+	fi
 
 clean:
 	@for d in $(SUBDIRS); do $(MAKE) -C $$d clean; done


### PR DESCRIPTION
## Summary
- don't abort coverage if one module fails
- report which modules failed

## Testing
- `make coverage` *(fails: Coverage failed in modules: minheap nlmon syslog2)*

------
https://chatgpt.com/codex/tasks/task_e_686a5edf72cc833082dc6857108e7d32