### PR TITLE
Add timezone offset helper

### DIFF
--- a/timeutil/test.c
+++ b/timeutil/test.c
@@ -179,6 +179,18 @@ static void test_atomic_ts_ops(void) {
   PRINT_TEST_PASSED();
 }
 
+static void test_timezone_offset(void) {
+  PRINT_TEST_START("tu_get_timezone_offset");
+
+  time_t off = tu_get_timezone_offset();
+  PRINT_TEST_INFO("timezone offset: %ld", (long)off);
+
+  assert(off >= -(14 * 3600) && off <= 14 * 3600);
+  assert(off % 60 == 0);
+
+  PRINT_TEST_PASSED();
+}
+
 int main(void) {
   tu_init();
 
@@ -187,6 +199,7 @@ int main(void) {
   test_tu_clock_monotonic_fast();
   test_pause_resume();
   test_atomic_ts_ops();
+  test_timezone_offset();
 
   printf(KGRN "====== All timeutil tests passed! ======\n" KNRM);
   return 0;

--- a/timeutil/timeutil.c
+++ b/timeutil/timeutil.c
@@ -121,3 +121,20 @@ void atomic_ts_cpy(atomic_timespec_t *dest, atomic_timespec_t *src) {
   atomic_ts_load(src, &tmp);
   atomic_ts_store(dest, &tmp);
 }
+
+time_t tu_get_timezone_offset(void) {
+  time_t now = time(NULL);
+  struct tm local_tm;
+  struct tm gm_tm;
+
+  if (now == (time_t)-1)
+    return 0;
+
+  localtime_r(&now, &local_tm);
+  gmtime_r(&now, &gm_tm);
+
+  time_t local_sec = mktime(&local_tm);
+  time_t gm_sec = mktime(&gm_tm);
+
+  return local_sec - gm_sec;
+}


### PR DESCRIPTION
## Summary
- implement `tu_get_timezone_offset` in timeutil
- test timezone offset retrieval

## Testing
- `make -C timeutil test`

------
https://chatgpt.com/codex/tasks/task_e_686a5f1331ec8330b3cfa5e1e30e49fc