### PR TITLE
Set default make goal for syslog2

### DIFF
--- a/syslog2/Makefile
+++ b/syslog2/Makefile
@@ -1,3 +1,4 @@
+.DEFAULT_GOAL := all
 CC = gcc
 CFLAGS = -Wall -Wextra -O3 -Wno-unused-parameter -ffunction-sections -fdata-sections -ggdb -I../timeutil
 AR = ar


### PR DESCRIPTION
## Summary
- make `all` the default goal for the syslog2 module
- ensure library builds when running `make -C ../syslog2`

## Testing
- `make -C syslog2`
- `make -C ../syslog2` from `timeutil`

------
https://chatgpt.com/codex/tasks/task_e_686a5f0b0ab48330ad9f3fa2b0c776d9