### PR TITLE
Fix syslog2 make target

### DIFF
--- a/minheap/Makefile
+++ b/minheap/Makefile
@@ -51,7 +51,7 @@ test: $(TEST_OBJ) $(LIBNAME) ../syslog2/libsyslog2.a
 	./test
 
 ../syslog2/libsyslog2.a:
-	$(MAKE) -C ../syslog2
+	$(MAKE) -C ../syslog2 all
 
 main.o: main.c minheap.h
 	$(CC) $(CFLAGS) -c main.c 

--- a/nlmon/Makefile
+++ b/nlmon/Makefile
@@ -34,7 +34,7 @@ all: dependencies $(LIBNAME) test $(if $(MAIN_OBJ), main)
 
 dependencies:
 	$(MAKE) -C ../timeutil
-	$(MAKE) -C ../syslog2
+	$(MAKE) -C ../syslog2 all
 
 $(LIBNAME): $(OBJ)
 	$(AR) $(ARFLAGS) $(LIBNAME) $(OBJ)


### PR DESCRIPTION
## Summary
- call `make -C ../syslog2 all` in nlmon and minheap Makefiles so libsyslog2 is built

## Testing
- `make -C minheap test`
- `make -C nlmon test TESTRUN=1`


------
https://chatgpt.com/codex/tasks/task_e_686a5f11d2b48330b18639644c06449c