### PR TITLE
Support filter lists in nlmon

### DIFF
--- a/nlmon/nlmon.h
+++ b/nlmon/nlmon.h
@@ -24,12 +24,13 @@ typedef struct {
     void *arg;
 } nlmon_filter_t;
 
-#ifdef TESTRUN
 typedef struct nlmon_test_msg {
   char *buf;
   size_t len;
 } nlmon_test_msg_t;
-#endif
+
+int nlmon_install_filters(const nlmon_filter_t *filters, size_t filter_cnt);
+void nlmon_clear_filters(void);
 
 #define NLMON_EVENT_LINK_UP 0x1
 #define NLMON_EVENT_LINK_DOWN 0x2
@@ -41,7 +42,6 @@ int init_netlink_monitor();
 void deinit_netlink_monitor(int fd);
 
 // Callback для обработки Netlink-событий
-void nl_handler_cb(uevent_t *ev, int fd, short events, nlmon_filter_t *filters,
-                   size_t filter_cnt);
+void nl_handler_cb(uevent_t *ev, int fd, short events);
 
 #endif // NL_MON_H

--- a/nlmon/nlmon_main.c
+++ b/nlmon/nlmon_main.c
@@ -71,6 +71,7 @@ int main(void) {
       .events = NLMON_EVENT_LINK_UP | NLMON_EVENT_LINK_DOWN,
       .cb = link_event_cb,
       .arg = &cb_arg};
+  nlmon_install_filters(&filter, 1);
 
   // Инициализация Netlink-мониторинга
   int fd = init_netlink_monitor();
@@ -126,7 +127,7 @@ int main(void) {
     }
     for (int i = 0; i < nfds; i++) {
       if (events[i].data.fd == fd) {
-        nl_handler_cb(NULL, fd, EPOLLIN, &filter, 1);
+        nl_handler_cb(NULL, fd, EPOLLIN);
       }
     }
   }
@@ -135,6 +136,7 @@ int main(void) {
   PRINT_INFO("Cleaning up...");
   close(epoll_fd);
   deinit_netlink_monitor(fd);
+  nlmon_clear_filters();
 
   printf("====== Netlink monitor demo completed! ======\n");
   return 0;


### PR DESCRIPTION
## Summary
- allow registering a filter table for nl_handler_cb
- expose helpers to install or clear filters
- extend nlmon tests with multiple interfaces and masks

## Testing
- `make -C nlmon test`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686a5ee432648330bdf968364713b62c