### PR TITLE
Fix flaky worker pool stop test

### DIFF
--- a/uevent/Makefile
+++ b/uevent/Makefile
@@ -17,7 +17,7 @@ CFLAGS_SO = $(CFLAGS) -fPIC
 # -O1 рекомендуется для санитайзеров, чтобы не оптимизировать слишком много
 # -g обязательно для получения читаемых стектрейсов
 CFLAGS_TEST = -fsanitize=thread,undefined -g
-LDFLAGS_TEST = -ltsan
+LDFLAGS_TEST = -ltsan -lubsan
 
 # Флаги линковки
 LDFLAGS = -lpthread

--- a/uevent/test.c
+++ b/uevent/test.c
@@ -128,6 +128,8 @@ void test_worker_pool_stop_wait() {
   uevent_worker_pool_t *pool = uevent_worker_pool_create(1);
   assert(pool != NULL);
 
+  uevent_worker_pool_enable_extra_workers(false);
+
   uevent_base_t *base = uevent_base_new_with_workers(8, 0);
   assert(base != NULL);
 
@@ -161,7 +163,9 @@ void test_worker_pool_stop_wait() {
   uevent_worker_pool_insert(pool, uev1, UEV_TIMEOUT, now);
   uevent_worker_pool_insert(pool, uev2, UEV_TIMEOUT, now);
 
-  msleep(10);
+  // Give the worker thread enough time to start executing the first task
+  // but not enough to finish it, ensuring the second task remains queued
+  msleep(50);
   uevent_worker_pool_stop(pool);
   uevent_worker_pool_wait_for_idle(pool);
 
@@ -171,6 +175,7 @@ void test_worker_pool_stop_wait() {
   uevent_free(uev2);
   uevent_deinit(base);
   uevent_worker_pool_destroy(pool);
+  uevent_worker_pool_enable_extra_workers(true);
   PRINT_TEST_PASSED();
 }
 

--- a/uevent/uevent_worker.c
+++ b/uevent/uevent_worker.c
@@ -16,6 +16,12 @@
 #define UEV_EXTRA_WORKER_TASKS 100
 #define UEV_MAX_WORKER_MULTIPLIER 8
 
+static _Atomic bool enable_extra_workers = true;
+
+void uevent_worker_pool_enable_extra_workers(bool enable) {
+  atomic_store(&enable_extra_workers, enable);
+}
+
 // Внутренняя структура для задачи в очереди
 typedef struct {
   uev_t *uev;
@@ -161,6 +167,9 @@ static void *uevent_extra_worker_thread(void *arg) {
 
 static void try_spawn_extra_worker(uevent_worker_pool_t *pool) {
   FUNC_START_DEBUG;
+  if (!atomic_load(&enable_extra_workers)) {
+    return;
+  }
   int max_workers = pool->num_workers * UEV_MAX_WORKER_MULTIPLIER;
   int old_total;
 

--- a/uevent/uevent_worker.h
+++ b/uevent/uevent_worker.h
@@ -15,6 +15,9 @@ typedef struct uevent_t uevent_t;
  */
 typedef struct uevent_worker_pool_t uevent_worker_pool_t;
 
+/** Control creation of temporary extra workers. Useful for tests. */
+void uevent_worker_pool_enable_extra_workers(bool enable);
+
 /**
  * @brief Создает и запускает пул рабочих потоков.
  *


### PR DESCRIPTION
## Summary
- link uevent tests with ubsan
- allow disabling extra worker creation
- disable extra workers for `test_worker_pool_stop_wait`

## Testing
- `make test` in `uevent`

------
https://chatgpt.com/codex/tasks/task_e_686a5f1765048330bc3287e2e24ec98e