### PR TITLE
Add coverage target for htable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SUBDIRS := htable minheap nlmon syslog2 timeutil uevent
-COV_DIRS := minheap nlmon syslog2 timeutil
+COV_DIRS := htable minheap nlmon syslog2 timeutil
 
 .PHONY: test coverage clean
 

--- a/htable/Makefile
+++ b/htable/Makefile
@@ -6,6 +6,11 @@ LIBNAME = libhtable.a
 OBJ = htable.o
 TEST_OBJ = test.o
 MAIN_OBJ = main.o
+LDFLAGS = -L.
+LIBS = -lhtable
+
+COV_CFLAGS = $(CFLAGS) -O0 -g -fprofile-arcs -ftest-coverage
+COV_LDFLAGS = $(LDFLAGS) -fprofile-arcs -ftest-coverage
 
 all: $(LIBNAME) main test
 
@@ -16,10 +21,10 @@ htable.o: htable.c htable.h
 	$(CC) $(CFLAGS) -c htable.c
 
 main: $(MAIN_OBJ) $(LIBNAME)
-	$(CC) $(CFLAGS) $(MAIN_OBJ) -L. -lhtable -o main
+	$(CC) $(CFLAGS) $(MAIN_OBJ) -o main $(LDFLAGS) $(LIBS)
 
 test: $(TEST_OBJ) $(LIBNAME)
-	$(CC) $(CFLAGS) $(TEST_OBJ) -L. -lhtable -o test
+	$(CC) $(CFLAGS) $(TEST_OBJ) -o test $(LDFLAGS) $(LIBS)
 	./test
 
 main.o: main.c htable.h
@@ -40,4 +45,11 @@ leak: test
 clean:
 	rm -f *.o *.gcov *.gcno *.gcda $(LIBNAME) main test callgrind.out
 
-.PHONY: all clean perf
+coverage: clean
+	$(MAKE) CFLAGS="$(COV_CFLAGS)" LDFLAGS="$(COV_LDFLAGS)" LIBS="$(LIBS)" test
+	@echo "=== Coverage report (gcov): ==="
+	@gcov htable.c | grep -A10 "File 'htable.c'"
+	@echo "=== Coverage report (summary): ==="
+	@gcov -b htable.c | grep -E 'Lines executed|Branches executed'
+
+.PHONY: all clean perf coverage


### PR DESCRIPTION
## Summary
- implement `coverage` in `htable/Makefile`
- list `htable` in `COV_DIRS` so root coverage runs it

## Testing
- `make coverage` *(fails later in minheap, but shows coverage for htable)*

------
https://chatgpt.com/codex/tasks/task_e_686a5f1570908330984880f5a0a5ce54