### PR TITLE
Refactor stress tests to deterministic runs

### DIFF
--- a/htable/test.c
+++ b/htable/test.c
@@ -165,16 +165,16 @@ void test_collision_handling() {
  * Выполняет большое количество случайных операций для проверки стабильности.
  */
 void test_stress_and_random_operations() {
-  PRINT_TEST_START("Stress test with random operations");
-  const int ITERATIONS = 50000;
-  const int KEY_SPACE = 1000;
+  PRINT_TEST_START("Stress test with deterministic operations");
+  const int ITERATIONS = 200;
+  const int KEY_SPACE = 100;
   htable_t *ht = htable_create(KEY_SPACE / 10); // Меньшая емкость для коллизий
 
   // "Теневая" структура для проверки корректности
   void **shadow_map = calloc(KEY_SPACE, sizeof(void *));
   assert(shadow_map != NULL);
 
-  srand(time(NULL));
+  srand(0); // fixed seed for deterministic behavior
 
   for (int i = 0; i < ITERATIONS; ++i) {
     int op = rand() % 3; // 0: set, 1: get, 2: del

--- a/minheap/test.c
+++ b/minheap/test.c
@@ -400,10 +400,12 @@ void test_update_node_key() {
  * Принцип 10: Интеграционный хаос-стресс тест.
  */
 void test_stress_random_operations() {
-  PRINT_TEST_START("Stress test with random operations");
-  const int NUM_NODES = 1000;
-  const int ITERATIONS = 50000;
+  PRINT_TEST_START("Stress test with deterministic operations");
+  const int NUM_NODES = 100;
+  const int ITERATIONS = 200;
   minheap_t *heap = mh_create(NUM_NODES);
+
+  srand(0); // fixed seed for reproducibility
 
   // Создаем пул узлов
   heap_value_t *nodes = calloc(NUM_NODES, sizeof(heap_value_t));
@@ -416,8 +418,6 @@ void test_stress_random_operations() {
   // Теневая структура для проверки - простой массив флагов (в куче или нет)
   bool *in_heap_shadow = calloc(NUM_NODES, sizeof(bool));
   assert(in_heap_shadow != NULL);
-
-  srand(time(NULL));
 
   for (int i = 0; i < ITERATIONS; ++i) {
     int node_idx = rand() % NUM_NODES;


### PR DESCRIPTION
## Summary
- refactor stress tests in `htable` and `minheap` to use fixed seeds and fewer iterations

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686a6c1763208330ab9a403bcbfc038b