### PR TITLE
Add list module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-SUBDIRS := htable minheap nlmon syslog2 timeutil uevent
-COV_DIRS := htable minheap nlmon syslog2 timeutil
+SUBDIRS := htable list minheap nlmon syslog2 timeutil uevent
+COV_DIRS := htable list minheap nlmon syslog2 timeutil
 
 .PHONY: test coverage clean
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains several small C libraries and utilities. Each module li
 ## Modules
 
 - **htable** – simple hash table implementation.
+- **list** – doubly linked list helpers from the Linux kernel.
 - **minheap** – binary min-heap container.
 - **nlmon** – netlink monitor used for tracking network events.
 - **syslog2** – lightweight asynchronous logging helper.

--- a/htable/htable.c
+++ b/htable/htable.c
@@ -1,5 +1,5 @@
 #include "htable.h"
-#include "../list.h"
+#include "../list/list.h"
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/htable/htable.h
+++ b/htable/htable.h
@@ -5,7 +5,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "../list.h" // Предполагаем, что list.h в родительском каталоге
+#include "../list/list.h" // Предполагаем, что list.h в родительском каталоге
 
 // Узел хэш-таблицы
 typedef struct htable_node {

--- a/list/Makefile
+++ b/list/Makefile
@@ -1,0 +1,55 @@
+CC = gcc
+CFLAGS = -Wall -Wextra -O3 -Wno-unused-parameter -ffunction-sections -fdata-sections -ggdb
+AR = ar
+ARFLAGS = rcs
+LIBNAME = liblist.a
+OBJ = list.o
+TEST_OBJ = test.o
+MAIN_OBJ = main.o
+LDFLAGS = -L.
+LIBS = -llist
+
+COV_CFLAGS = $(CFLAGS) -O0 -g -fprofile-arcs -ftest-coverage
+COV_LDFLAGS = $(LDFLAGS) -fprofile-arcs -ftest-coverage
+
+all: $(LIBNAME) main test
+
+$(LIBNAME): $(OBJ)
+	$(AR) $(ARFLAGS) $(LIBNAME) $(OBJ)
+
+list.o: list.c list.h
+	$(CC) $(CFLAGS) -c list.c
+
+main: $(MAIN_OBJ) $(LIBNAME)
+	$(CC) $(CFLAGS) $(MAIN_OBJ) -o main $(LDFLAGS) $(LIBS)
+
+test: $(TEST_OBJ) $(LIBNAME)
+	$(CC) $(CFLAGS) $(TEST_OBJ) -o test $(LDFLAGS) $(LIBS)
+	./test
+
+main.o: main.c list.h
+	$(CC) $(CFLAGS) -c main.c
+
+test.o: test.c list.h
+	$(CC) $(CFLAGS) -c test.c
+
+perf: test
+	@echo "Running valgrind callgrind profiler..."
+	valgrind --tool=callgrind --callgrind-out-file=callgrind.out ./test
+	callgrind_annotate --inclusive=yes --auto=yes callgrind.out | head -n60
+
+leak: test
+	@echo "Running valgrind memcheck for memory leaks..."
+	valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes ./test
+
+clean:
+	rm -f *.o *.gcov *.gcno *.gcda $(LIBNAME) main test callgrind.out
+
+coverage: clean
+	$(MAKE) CFLAGS="$(COV_CFLAGS)" LDFLAGS="$(COV_LDFLAGS)" LIBS="$(LIBS)" test
+	@echo "=== Coverage report (gcov): ==="
+	@gcov list.c | grep -A10 "File 'list.c'"
+	@echo "=== Coverage report (summary): ==="
+	@gcov -b list.c | grep -E 'Lines executed|Branches executed'
+
+.PHONY: all clean perf leak coverage

--- a/list/list.c
+++ b/list/list.c
@@ -1,0 +1,9 @@
+#include "list.h"
+
+int list_is_empty(const struct list_head *head) {
+    return list_empty(head);
+}
+
+int list_count(const struct list_head *head) {
+    return list_size(head);
+}

--- a/list/list.h
+++ b/list/list.h
@@ -211,4 +211,6 @@ static inline void list_splice_init(struct list_head *list,
   }
 }
 
+int list_is_empty(const struct list_head *head);
+int list_count(const struct list_head *head);
 #endif /* _LINUX_LIST_H_ */

--- a/list/main.c
+++ b/list/main.c
@@ -1,0 +1,33 @@
+#include "list.h"
+
+#include <stdio.h>
+#include <string.h>
+
+struct item {
+    char name[16];
+    int value;
+    struct list_head node;
+};
+
+int main(void) {
+    struct list_head head;
+    INIT_LIST_HEAD(&head);
+
+    struct item items[3] = {
+        {"first", 1},
+        {"second", 2},
+        {"third", 3}
+    };
+
+    for (int i = 0; i < 3; ++i) {
+        INIT_LIST_HEAD(&items[i].node);
+        list_add_tail(&items[i].node, &head);
+    }
+
+    struct item *pos;
+    list_for_each_entry(pos, &head, node) {
+        printf("%s => %d\n", pos->name, pos->value);
+    }
+
+    return 0;
+}

--- a/list/test.c
+++ b/list/test.c
@@ -1,0 +1,57 @@
+#include "list.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#define KNRM "\x1B[0m"
+#define KGRN "\x1B[32m"
+#define KYEL "\x1B[33m"
+#define KCYN "\x1B[36m"
+
+#define PRINT_TEST_START(name) \
+  printf(KCYN "%s:%d --- Starting Test: %s ---\n" KNRM, __FILE__, __LINE__, name)
+#define PRINT_TEST_PASSED() printf(KGRN "--- Test Passed ---\n\n" KNRM)
+
+struct mynode {
+    int val;
+    struct list_head node;
+};
+
+static void test_basic(void) {
+    PRINT_TEST_START("list basic");
+    struct list_head head;
+    INIT_LIST_HEAD(&head);
+    assert(list_is_empty(&head));
+    assert(list_count(&head) == 0);
+
+    struct mynode a = { .val = 1 }, b = { .val = 2 }, c = { .val = 3 };
+    INIT_LIST_HEAD(&a.node);
+    INIT_LIST_HEAD(&b.node);
+    INIT_LIST_HEAD(&c.node);
+
+    list_add(&a.node, &head);
+    list_add_tail(&b.node, &head);
+    list_add(&c.node, &head);
+
+    assert(!list_is_empty(&head));
+    assert(list_count(&head) == 3);
+
+    int sum = 0;
+    struct mynode *p;
+    list_for_each_entry(p, &head, node) {
+        sum += p->val;
+    }
+    assert(sum == 6);
+
+    list_del(&a.node);
+    list_del(&b.node);
+    list_del(&c.node);
+    assert(list_is_empty(&head));
+    PRINT_TEST_PASSED();
+}
+
+int main(void) {
+    test_basic();
+    return 0;
+}

--- a/uevent/uevent.c
+++ b/uevent/uevent.c
@@ -17,7 +17,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 
-#include "../list.h"
+#include "../list/list.h"
 #include "../minheap/minheap.h"
 #include "../syslog2/syslog2.h"
 #include "../timeutil/timeutil.h"

--- a/uevent/uevent.h
+++ b/uevent/uevent.h
@@ -1,7 +1,7 @@
 #ifndef LIBUEVENT_UEVENT_H
 #define LIBUEVENT_UEVENT_H
 
-#include "../list.h"
+#include "../list/list.h"
 #include "../minheap/minheap.h"
 #include "../syslog2/syslog2.h"
 #include "../timeutil/timeutil.h"

--- a/uevent/uevent_worker.c
+++ b/uevent/uevent_worker.c
@@ -2,7 +2,7 @@
 #define _GNU_SOURCE
 #endif
 
-#include "../list.h"
+#include "../list/list.h"
 #include "uevent.h" // uevent_t и uevent_cb_t
 
 #include "uevent_internal.h"


### PR DESCRIPTION
## Summary
- turn `list.h` into a standalone module
- add build and tests for the new `list` module
- adjust other modules to include the header from the new location
- register `list` in the root Makefile and README

## Testing
- `make test`
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_686b2c287c8c8330ab897e4d75994a78