### PR TITLE
Fix race in uevent callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ dkms.conf
 
 # debug information files
 *.dwo
+uevent/test_bin

--- a/uevent/uevent.c
+++ b/uevent/uevent.c
@@ -560,6 +560,10 @@ static void uevent_user_cb_wrapper(uevent_t *ev, int fd, short events, uint64_t 
   if (!uevent_try_lock(ev)) return;
 
   uevent_base_t *base = ATOM_LOAD_ACQ(ev->base);
+  if (base == NULL) {
+    uevent_unlock(ev);
+    return;
+  }
   // скипаем wakeup_event
   if (&base->wakeup_event == ev) {
     if (cb) {


### PR DESCRIPTION
## Summary
- ignore `test_bin` built by uevent tests
- avoid dereferencing `base` when it can be NULL in `uevent_user_cb_wrapper`

## Testing
- `make test` in uevent module
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686b3019a5448330816ab128c87e6e35