### PR TITLE
Fix static event reuse in uevent

### DIFF
--- a/uevent/uevent.c
+++ b/uevent/uevent.c
@@ -127,12 +127,17 @@ static void uevent_reset_static_ev(uevent_t *ev) {
   ATOM_STORE_REL(ev->modification_lock, 0);
   ATOM_STORE_REL(ev->active_fd, 0);
   ATOM_STORE_REL(ev->active_timer, 0);
+  ATOM_STORE_REL(ev->pending_free, 0);
+  ATOM_STORE_REL(ev->is_in_worker_pool, 0);
   ev->uev = NULL; // Обнуляем ev->uev для статических событий
   ev->fd = -1;
   ev->events = 0;
   ev->cb = NULL;
   ev->cb_wrapper = NULL;
   ev->arg = NULL;
+  ev->name = NULL;
+  ev->timer_node.key = 0;
+  ev->timer_node.idx = 0;
 }
 
 // внутренняя функция освобождения памяти или сброса для статического события


### PR DESCRIPTION
## Summary
- reset additional fields when freeing static events
- clean up timer node to avoid stale state

## Testing
- `make -C uevent DEBUG=1 test`
- `make -C uevent DEBUG=1 robust_test`
- `make clean`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686b2e9b31588330b8c0c3e054d373ee