### PR TITLE
Use custom allocators in uevent tests

### DIFF
--- a/uevent/uevent_internal.h
+++ b/uevent/uevent_internal.h
@@ -1,5 +1,20 @@
 // uevent_internal.h
 
+#include <stdlib.h>
+
+typedef void *(*uevent_malloc_func_t)(size_t);
+typedef void *(*uevent_calloc_func_t)(size_t, size_t);
+
+extern uevent_malloc_func_t uevent_malloc_hook;
+extern uevent_calloc_func_t uevent_calloc_hook;
+
+void uevent_set_allocators(uevent_malloc_func_t mfn,
+                           uevent_calloc_func_t cfn);
+void uevent_reset_allocators(void);
+
+#define UEV_MALLOC(sz) uevent_malloc_hook(sz)
+#define UEV_CALLOC(n, sz) uevent_calloc_hook((n), (sz))
+
 // --- Ссылки (threadsafe, но низкоуровневые) ---
 void uevent_ref(uev_t *uev);  // atomic
 int uevent_unref(uev_t *uev); // atomic

--- a/uevent/uevent_worker.c
+++ b/uevent/uevent_worker.c
@@ -214,7 +214,7 @@ uevent_worker_pool_t *uevent_worker_pool_create(int num_workers) {
 
   if (num_workers <= 0) return NULL;
 
-  pool = calloc(1, sizeof(uevent_worker_pool_t));
+  pool = UEV_CALLOC(1, sizeof(uevent_worker_pool_t));
   if (pool == NULL) return NULL;
 
   pool->num_workers = num_workers;
@@ -227,7 +227,7 @@ uevent_worker_pool_t *uevent_worker_pool_create(int num_workers) {
   if (pthread_mutex_init(&pool->idle_mutex, NULL) != 0) goto fail_task_cond;
   if (pthread_cond_init(&pool->idle_cond, NULL) != 0) goto fail_idle_mutex;
 
-  pool->workers = calloc(num_workers, sizeof(pthread_t));
+  pool->workers = UEV_CALLOC(num_workers, sizeof(pthread_t));
   if (pool->workers == NULL) goto fail_idle_cond;
 
   for (i = 0; i < pool->num_workers; i++) {
@@ -269,7 +269,7 @@ void uevent_worker_pool_insert(uevent_worker_pool_t *pool, uev_t *uev, short tri
 
   TINIT;
   TMARK(10, "START");
-  uevent_task_t *task = malloc(sizeof(uevent_task_t));
+  uevent_task_t *task = UEV_MALLOC(sizeof(uevent_task_t));
   if (task == NULL) {
     syslog2(LOG_ERR, "Failed to allocate memory for uevent task");
     return;


### PR DESCRIPTION
## Summary
- add allocator hooks in uevent_internal.h
- implement set/reset functions in uevent.c
- switch uevent code to use allocator hooks
- rework uevent tests to use custom calloc/malloc

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686b38e09880833092a90c356e75bb7e