### PR TITLE
Use timeutil constants in minheap test

### DIFF
--- a/minheap/test.c
+++ b/minheap/test.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <sys/time.h> // gettimeofday
 #include <time.h>
+#include "../timeutil/timeutil.h"
 
 // --- Макросы ---
 #ifndef MIN
@@ -52,8 +53,6 @@ typedef struct {
   int value;
 } heap_value_t;
 
-#define MS_PER_SEC (1000U)
-#define NS_PER_MS (1000000U)
 
 static inline int clock_gettime_fast(struct timespec *ts, bool raw) {
   return clock_gettime(raw ? CLOCK_MONOTONIC_RAW : CLOCK_MONOTONIC, ts);


### PR DESCRIPTION
## Summary
- include timeutil.h in `minheap/test.c`
- remove hardcoded MS_PER_SEC and NS_PER_MS constants

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686b40c914ec8330a6ce177fcb547073