### PR TITLE
Fix unused variable warnings in tests

### DIFF
--- a/nlmon/nlmon_test.c
+++ b/nlmon/nlmon_test.c
@@ -118,6 +118,7 @@ static void test_nl_handler_cb(void) {
       .tu_pause_start = mock_tu_pause_start,
       .tu_pause_end = mock_tu_pause_end};
   uevent_t ev = {.dummy = 0};
+  (void)ev;
   pause_end_called = 0;
 
   const char *names[] = {ifname, NULL};
@@ -177,7 +178,9 @@ static void test_nl_handler_cb_invalid_ifname(void) {
       .events = NLMON_EVENT_LINK_UP,
       .cb = filter_cb,
       .arg = &cb_arg};
+  (void)filter;
   uevent_t ev = {.dummy = 0};
+  (void)ev;
   pause_end_called = 0;
 
   int fd = init_netlink_monitor();
@@ -204,6 +207,7 @@ static void test_nl_handler_cb_multiple_filters(void) {
   nlmon_install_filters(filters, 2);
 
   uevent_t ev = {.dummy = 0};
+  (void)ev;
   cb1_called = cb2_called = 0;
 
   int fd = init_netlink_monitor();

--- a/uevent/test.c
+++ b/uevent/test.c
@@ -63,6 +63,7 @@ void set_calloc_fail(int count) { fail_calloc = count; }
 void set_epoll_create1_fail(int count) { fail_epoll_create1 = count; }
 void set_eventfd_fail(int count) { fail_eventfd = count; }
 
+static void *test_malloc(size_t size) __attribute__((unused));
 static void *test_malloc(size_t size) {
   if (fail_malloc > 0) {
     fail_malloc--;


### PR DESCRIPTION
## Summary
- silence `unused variable` warnings in nlmon tests
- mark test_malloc as unused in uevent tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686b40ec7300833084d79b27cb8e0668