### PR TITLE
Add injection hooks for syslog2

### DIFF
--- a/syslog2/syslog2.h
+++ b/syslog2/syslog2.h
@@ -28,6 +28,13 @@ extern const char *last_function[MAX_THREADS];
 extern pid_t thread_ids[MAX_THREADS]; // Реальные идентификаторы потоков
 extern pthread_t pthread_ids[MAX_THREADS];
 
+typedef struct syslog2_mod_init_args_t {
+  void (*log)(int, const char *, ...);
+  int (*get_time)(struct timespec *);
+} syslog2_mod_init_args_t;
+
+int syslog2_mod_init(const syslog2_mod_init_args_t *args);
+
 // Макрос для записи имени функции
 // Макрос для записи имени функции
 #define SET_CURRENT_FUNCTION()           \


### PR DESCRIPTION
## Summary
- allow injecting log/time functions into syslog2
- use function pointers inside syslog2
- expose `syslog2_mod_init` in the public header
- test that injected functions are invoked

## Testing
- `make test` (in `syslog2` module)

------
https://chatgpt.com/codex/tasks/task_e_686c0582a80483309bc93d2fbf81734a