### PR TITLE
Add initialization hooks for netlink_getlink

### DIFF
--- a/netlink_getlink/README.md
+++ b/netlink_getlink/README.md
@@ -16,3 +16,9 @@ or make with leakcheck `make LEAKCHECK=1`
 run `./build/getlink_shared` and check
 leakcheck report `cat /tmp/leak_info.txt`
 
+## Initialization
+Before using the library functions you may optionally call
+`netlink_getlink_mod_init()` to provide custom logging or time retrieval
+functions. Passing `NULL` sets defaults to use `syslog2` for logging and
+`clock_gettime` for time.
+

--- a/netlink_getlink/libnl_getlink.c
+++ b/netlink_getlink/libnl_getlink.c
@@ -13,6 +13,7 @@
 #include <sys/socket.h>
 #include <sys/stat.h> // fchmod
 #include <sys/time.h> /* timeval_t struct */
+#include <time.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -20,6 +21,19 @@
 #include "../syslog2/syslog2.h"
 
 #include "../leak_detector_c/leak_detector.h"
+
+static netlink_getlink_log_fn_t log_func = syslog2_;
+static netlink_getlink_time_fn_t time_func = clock_gettime;
+static bool nlgl_initialized = false;
+
+int netlink_getlink_mod_init(const netlink_getlink_mod_init_args_t *args);
+static void ensure_initialized(void);
+
+static void ensure_initialized(void) {
+  if (!nlgl_initialized) {
+    netlink_getlink_mod_init(NULL);
+  }
+}
 
 #define parse_rtattr_nested(tb, max, rta) \
   (parse_rtattr((tb), (max), RTA_DATA(rta), RTA_PAYLOAD(rta)))
@@ -65,7 +79,8 @@ static int addattr_l(struct nlmsghdr *n, unsigned int maxlen, int type, const vo
   struct rtattr *rta;
 
   if (NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len) > maxlen) {
-    syslog2(LOG_NOTICE, "addattr_l ERROR: message exceeded bound of %d", maxlen);
+    log_func(LOG_NOTICE, __func__, __FILENAME__, __LINE__,
+             "addattr_l ERROR: message exceeded bound of %d", true, maxlen);
     return -1;
   }
   rta = NLMSG_TAIL(n);
@@ -82,6 +97,7 @@ int addattr32(struct nlmsghdr *n, unsigned int maxlen, int type, __u32 data) {
 }
 
 void free_netdev_list(struct slist_head *list) {
+  ensure_initialized();
   FUNC_START_DEBUG;
   netdev_item_t *item = NULL;
   netdev_item_t *tmp = NULL;
@@ -94,6 +110,7 @@ void free_netdev_list(struct slist_head *list) {
 }
 
 netdev_item_t *ll_get_by_index(struct slist_head *list, int index) {
+  ensure_initialized();
   // FUNC_START_DEBUG;
   netdev_item_t *item;
   slist_for_each_entry(item, list, list) {
@@ -119,13 +136,16 @@ static int send_msg() {
   };
   int err = addattr32(&req.nlh, sizeof(req), IFLA_EXT_MASK, RTEXT_FILTER_VF);
   if (err) {
-    syslog2(LOG_ERR, "%s addattr32(&req.nlh, sizeof(req), IFLA_EXT_MASK, RTEXT_FILTER_VF)", strerror(errno));
+    log_func(LOG_ERR, __func__, __FILENAME__, __LINE__,
+             "%s addattr32(&req.nlh, sizeof(req), IFLA_EXT_MASK, RTEXT_FILTER_VF)",
+             true, strerror(errno));
     return -1;
   }
 
   int sd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE); /* open socket */
   if (sd < 0) {
-    syslog2(LOG_ERR, "%s socket()", strerror(errno));
+    log_func(LOG_ERR, __func__, __FILENAME__, __LINE__, "%s socket()", true,
+             strerror(errno));
     return -1;
   }
   fchmod(sd, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
@@ -145,7 +165,8 @@ static int send_msg() {
   status = send(sd, &req, req.nlh.nlmsg_len, 0);
   if (status < 0) {
     status = errno;
-    syslog2(LOG_NOTICE, "%s send()", strerror(errno));
+    log_func(LOG_NOTICE, __func__, __FILENAME__, __LINE__, "%s send()", true,
+             strerror(errno));
     close(sd); /* close socket */
     return -1;
   }
@@ -176,10 +197,12 @@ static ssize_t recv_msg(int sd, void **buf) {
     return ret;
   } else if (ret < 0) {
     if (errno == EINTR) {
-      syslog2(LOG_WARNING, "select EINTR");
+      log_func(LOG_WARNING, __func__, __FILENAME__, __LINE__, "select EINTR",
+               true);
       return ret;
     }
-    syslog2(LOG_ERR, "select error=%s", strerror(errno));
+    log_func(LOG_ERR, __func__, __FILENAME__, __LINE__, "select error=%s", true,
+             strerror(errno));
     return ret;
   }
 
@@ -208,7 +231,8 @@ static int parse_recv_chunk(void *buf, ssize_t len, struct slist_head *list) {
 
   for (nh = (struct nlmsghdr *)buf; NLMSG_OK(nh, len); nh = NLMSG_NEXT(nh, len)) {
     if (counter > 100) {
-      syslog2(LOG_ALERT, "counter %zu > 100", counter);
+      log_func(LOG_ALERT, __func__, __FILENAME__, __LINE__,
+               "counter %zu > 100", true, counter);
       break;
     }
 
@@ -242,7 +266,8 @@ static int parse_recv_chunk(void *buf, ssize_t len, struct slist_head *list) {
     if (!dev) {
       dev = calloc(1, sizeof(netdev_item_t));
       if (!dev) {
-        syslog2(LOG_ALERT, "Failed to allocate memory for netdev_item_s.");
+        log_func(LOG_ALERT, __func__, __FILENAME__, __LINE__,
+                 "Failed to allocate memory for netdev_item_s.", true);
         return -1;
       }
     }
@@ -260,7 +285,8 @@ static int parse_recv_chunk(void *buf, ssize_t len, struct slist_head *list) {
     }
 
     if (!tb[IFLA_IFNAME]) {
-      syslog2(LOG_WARNING, "IFLA_IFNAME attribute is missing.");
+      log_func(LOG_WARNING, __func__, __FILENAME__, __LINE__,
+               "IFLA_IFNAME attribute is missing.", true);
       continue;
     } else {
       strcpy(dev->name, (char *)RTA_DATA(tb[IFLA_IFNAME]));
@@ -288,6 +314,7 @@ static int parse_recv_chunk(void *buf, ssize_t len, struct slist_head *list) {
 }
 
 int get_netdev(struct slist_head *list) {
+  ensure_initialized();
   FUNC_START_DEBUG;
   int sd;
   void *buf;
@@ -304,5 +331,17 @@ int get_netdev(struct slist_head *list) {
   }
 
   close(sd); /* close socket */
+  return 0;
+}
+
+int netlink_getlink_mod_init(const netlink_getlink_mod_init_args_t *args) {
+  if (!args) {
+    log_func = syslog2_;
+    time_func = clock_gettime;
+  } else {
+    log_func = args->log ? args->log : syslog2_;
+    time_func = args->get_time ? args->get_time : clock_gettime;
+  }
+  nlgl_initialized = true;
   return 0;
 }

--- a/netlink_getlink/libnl_getlink.h
+++ b/netlink_getlink/libnl_getlink.h
@@ -13,6 +13,8 @@
 
 #include "../syslog2/syslog2.h"
 
+#include <time.h>
+
 #include "slist.h"
 
 #ifndef IFNAMSIZ
@@ -41,6 +43,18 @@ typedef struct nl_req {
   struct nlmsghdr hdr;
   struct rtgenmsg gen;
 } nl_req_s;
+
+typedef void (*netlink_getlink_log_fn_t)(int, const char *, const char *, int,
+                                         const char *, bool, ...);
+
+typedef int (*netlink_getlink_time_fn_t)(clockid_t, struct timespec *);
+
+typedef struct netlink_getlink_mod_init_args_t {
+  netlink_getlink_log_fn_t log;
+  netlink_getlink_time_fn_t get_time;
+} netlink_getlink_mod_init_args_t;
+
+int netlink_getlink_mod_init(const netlink_getlink_mod_init_args_t *args);
 
 int get_netdev(struct slist_head *list);
 netdev_item_t *ll_get_by_index(struct slist_head *list, int index);

--- a/netlink_getlink/test.c
+++ b/netlink_getlink/test.c
@@ -1,8 +1,32 @@
 #include "libnl_getlink.h"
 #include <assert.h>
 #include <stdio.h>
+#include <time.h>
+
+static int log_called = 0;
+
+static void mock_log(int pri, const char *func, const char *file, int line,
+                     const char *fmt, bool nl, ...) {
+  (void)pri;
+  (void)func;
+  (void)file;
+  (void)line;
+  (void)fmt;
+  (void)nl;
+  log_called++;
+}
+
+static int mock_time(clockid_t clk, struct timespec *ts) {
+  (void)clk;
+  ts->tv_sec = 0;
+  ts->tv_nsec = 0;
+  return 0;
+}
 
 int main(void) {
+  netlink_getlink_mod_init(&(netlink_getlink_mod_init_args_t){
+      .log = mock_log,
+      .get_time = mock_time});
   struct slist_head list;
   INIT_SLIST_HEAD(&list);
 


### PR DESCRIPTION
## Summary
- add `netlink_getlink_mod_init()` with customizable logging and time retrieval
- invoke initialization automatically on first public call
- replace direct `syslog2` uses with new log hook
- update `README` for new initialization API
- extend tests to use mocked logging/time functions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686c10ce98b08330a1b5600e4e4ae664