### PR TITLE
Add DI hooks to nlarpcache

### DIFF
--- a/netlink_arp_cache/README.md
+++ b/netlink_arp_cache/README.md
@@ -1,6 +1,16 @@
 # arp cache getter via netlink kernel socket
 No dependencies program.
 
+### Initialization
+
+Use `nlarpcache_mod_init()` to override logging or time callbacks:
+
+```c
+nlarpcache_mod_init(&(netlink_arp_cache_mod_init_args_t){
+  .log = custom_log,
+  .get_time = custom_time});
+```
+
 ## Howto build
 ```
 git clone <repo_url>

--- a/netlink_arp_cache/libnlarpcache.h
+++ b/netlink_arp_cache/libnlarpcache.h
@@ -9,15 +9,26 @@
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <unistd.h> /* close() */
+#include <time.h>
 
 
 /* structure to store arp entries */
 typedef struct _arp_cache {
-    struct nlmsghdr *nl_hdr;
-    struct rtattr *tb[NDA_MAX + 1];
-    uint8_t ndm_family;
-    uint16_t ndm_state; /* ndmsg structure variable */
+  struct nlmsghdr *nl_hdr;
+  struct rtattr *tb[NDA_MAX + 1];
+  uint8_t ndm_family;
+  uint16_t ndm_state; /* ndmsg structure variable */
 } arp_cache;
+
+typedef void (*nlarp_log_fn_t)(int, const char *, ...);
+typedef int (*nlarp_time_fn_t)(struct timespec *);
+
+typedef struct netlink_arp_cache_mod_init_args_t {
+  nlarp_log_fn_t log;
+  nlarp_time_fn_t get_time;
+} netlink_arp_cache_mod_init_args_t;
+
+int nlarpcache_mod_init(const netlink_arp_cache_mod_init_args_t *args);
 
 
 void parse_rtattr(struct rtattr *tb[], int max, struct rtattr *rta, unsigned len);

--- a/netlink_arp_cache/test.c
+++ b/netlink_arp_cache/test.c
@@ -1,11 +1,48 @@
 #include "libnlarpcache.h"
+#include "../syslog2/syslog2.h"
 
 #include <assert.h>
 #include <linux/rtnetlink.h>
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
+#include <time.h>
+
+static int log_called = 0;
+static int time_called = 0;
+
+static void mock_log(int pri, const char *fmt, ...) {
+  (void)pri;
+  (void)fmt;
+  log_called++;
+}
+
+static int mock_time(struct timespec *ts) {
+  if (ts) {
+    ts->tv_sec = 0;
+    ts->tv_nsec = 0;
+  }
+  time_called++;
+  return 0;
+}
+
+#ifdef TESTRUN
+int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
+           struct timeval *timeout) {
+  (void)nfds;
+  (void)readfds;
+  (void)writefds;
+  (void)exceptfds;
+  (void)timeout;
+  errno = EINTR;
+  return -1;
+}
+#endif
 
 int main(void) {
+  nlarpcache_mod_init(&(netlink_arp_cache_mod_init_args_t){
+      .log = mock_log, .get_time = mock_time});
+
   unsigned char buf[256];
 
   struct rtattr *rta1 = (struct rtattr *)buf;
@@ -21,9 +58,26 @@ int main(void) {
   unsigned len = RTA_SPACE(4) + RTA_SPACE(6);
   struct rtattr *tb[NDA_MAX + 1] = {0};
   parse_rtattr(tb, NDA_MAX, rta1, len);
+  assert(time_called == 1);
 
   assert(tb[NDA_DST] == rta1);
   assert(tb[NDA_LLADDR] == rta2);
+
+  void *rb = NULL;
+  struct {
+    struct nlmsghdr n;
+    struct ndmsg ndm;
+    char buf[0];
+  } req = {
+      .n.nlmsg_len = NLMSG_LENGTH(sizeof(struct ndmsg)),
+      .n.nlmsg_type = RTM_GETNEIGH,
+      .n.nlmsg_flags = NLM_F_REQUEST | NLM_F_ROOT,
+  };
+
+  send_recv(&req, req.n.nlmsg_len, &rb);
+  free(rb);
+
+  assert(log_called == 1);
 
   printf("All tests passed\n");
   return 0;


### PR DESCRIPTION
## Summary
- add dependency injection to netlink_arp_cache with `nlarpcache_mod_init`
- replace direct syslog2 usage with callbacks
- expose log/time hook types in header
- document the new init routine and provide unit test using custom callbacks

## Testing
- `make test` (all modules)
- manual compilation and execution of netlink_arp_cache test

------
https://chatgpt.com/codex/tasks/task_e_686c10cf85b8833099b4f543604c9ae1