### PR TITLE
Add uniform mod_init interface

### DIFF
--- a/htable/htable.c
+++ b/htable/htable.c
@@ -3,6 +3,24 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+static void *(*htable_malloc_hook)(size_t) = malloc;
+static void (*htable_free_hook)(void *) = free;
+static void (*htable_log_hook)(const char *, ...) = NULL;
+
+void htable_mod_init(const htable_mod_init_args_t *args) {
+  if (args) {
+    htable_malloc_hook = args->malloc_fn ? args->malloc_fn : malloc;
+    htable_free_hook = args->free_fn ? args->free_fn : free;
+    htable_log_hook = args->log_fn;
+  } else {
+    htable_malloc_hook = malloc;
+    htable_free_hook = free;
+    htable_log_hook = NULL;
+  }
+}
 
 // Хеш-функция по ключу
 static inline unsigned int htable_hash(uintptr_t key, size_t capacity) {

--- a/htable/htable.h
+++ b/htable/htable.h
@@ -57,4 +57,12 @@ void *htable_get(htable_t *ht, uintptr_t key);
  */
 void htable_del(htable_t *ht, uintptr_t key);
 
+typedef struct {
+  void *(*malloc_fn)(size_t);
+  void (*free_fn)(void *);
+  void (*log_fn)(const char *, ...);
+} htable_mod_init_args_t;
+
+void htable_mod_init(const htable_mod_init_args_t *args);
+
 #endif // HTABLE_H

--- a/htable/test.c
+++ b/htable/test.c
@@ -205,6 +205,7 @@ void test_stress_and_random_operations() {
 
 // --- Главная функция для запуска всех тестов ---
 int main(void) {
+  htable_mod_init(NULL);
   // Принцип 6: Автоматический запуск всех тестов
   test_create_and_free();
   test_set_and_get_single_item();

--- a/leak_detector_c/leak_detector.c
+++ b/leak_detector_c/leak_detector.c
@@ -3,6 +3,23 @@
 #include <string.h>
 
 #include "leak_detector.h"
+#include <stdarg.h>
+
+static void *(*leak_detector_malloc_hook)(size_t) = malloc;
+static void (*leak_detector_free_hook)(void *) = free;
+static void (*leak_detector_log_hook)(const char *, ...) = NULL;
+
+void leak_detector_mod_init(const leak_detector_mod_init_args_t *args) {
+  if (args) {
+    leak_detector_malloc_hook = args->malloc_fn ? args->malloc_fn : malloc;
+    leak_detector_free_hook = args->free_fn ? args->free_fn : free;
+    leak_detector_log_hook = args->log_fn;
+  } else {
+    leak_detector_malloc_hook = malloc;
+    leak_detector_free_hook = free;
+    leak_detector_log_hook = NULL;
+  }
+}
 
 #undef malloc
 #undef realloc

--- a/leak_detector_c/leak_detector.h
+++ b/leak_detector_c/leak_detector.h
@@ -9,6 +9,7 @@
 #define realloc(ptr, size) xrealloc(ptr, size, __FILE__, __LINE__)
 #define free(mem_ref) xfree(mem_ref)
 #endif
+#include <stddef.h>
 
 struct _MEM_INFO {
   void *address;
@@ -33,5 +34,13 @@ void xfree(void *mem_ref);
 void add_mem_info(void *mem_ref, unsigned int size, const char *file, unsigned int line);
 void remove_mem_info(void *mem_ref);
 void report_mem_leak(void);
+
+typedef struct {
+  void *(*malloc_fn)(size_t);
+  void (*free_fn)(void *);
+  void (*log_fn)(const char *, ...);
+} leak_detector_mod_init_args_t;
+
+void leak_detector_mod_init(const leak_detector_mod_init_args_t *args);
 
 #endif

--- a/leak_detector_c/test.c
+++ b/leak_detector_c/test.c
@@ -6,6 +6,7 @@
 #include "../test_util.h"
 
 int main(void) {
+  leak_detector_mod_init(NULL);
 #ifdef LEAKCHECK
   PRINT_TEST_START("basic leak detector");
   char *tmp = malloc(10);

--- a/libpcap-dhcp-capture/pcap_dhcp.c
+++ b/libpcap-dhcp-capture/pcap_dhcp.c
@@ -2,6 +2,25 @@
 #include "../syslog2/syslog2.h"
 
 #include "../leak_detector_c/leak_detector.h"
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void *(*pcap_dhcp_malloc_hook)(size_t) = malloc;
+static void (*pcap_dhcp_free_hook)(void *) = free;
+static void (*pcap_dhcp_log_hook)(const char *, ...) = NULL;
+
+void pcap_dhcp_mod_init(const pcap_dhcp_mod_init_args_t *args) {
+  if (args) {
+    pcap_dhcp_malloc_hook = args->malloc_fn ? args->malloc_fn : malloc;
+    pcap_dhcp_free_hook = args->free_fn ? args->free_fn : free;
+    pcap_dhcp_log_hook = args->log_fn;
+  } else {
+    pcap_dhcp_malloc_hook = malloc;
+    pcap_dhcp_free_hook = free;
+    pcap_dhcp_log_hook = NULL;
+  }
+}
 
 /*
  * Convert a token value to a string; use "fmt" if not found.

--- a/libpcap-dhcp-capture/pcap_dhcp.h
+++ b/libpcap-dhcp-capture/pcap_dhcp.h
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stddef.h>
 #include <string.h>
 
 /*
@@ -107,7 +108,17 @@ pcap_t *dhcp_pcap_open_live(const char *device);
 
 const char *tok2str(const struct tok *lp, const char *fmt, const u_int v);
 
-void dhcp_packet_handler(u_char *args, const struct pcap_pkthdr *h, const uint8_t *p);
+void dhcp_packet_handler(u_char *args, const struct pcap_pkthdr *h,
+                         const uint8_t *p);
 char *parse_vendor_specific_option_12(const nd_byte *vend_data, size_t vend_len);
 size_t calc_vendor_specific_size(struct bootp *sample);
+
+typedef struct {
+  void *(*malloc_fn)(size_t);
+  void (*free_fn)(void *);
+  void (*log_fn)(const char *, ...);
+} pcap_dhcp_mod_init_args_t;
+
+void pcap_dhcp_mod_init(const pcap_dhcp_mod_init_args_t *args);
+
 #endif /* pcap_dhcp.h */

--- a/libpcap-dhcp-capture/test.c
+++ b/libpcap-dhcp-capture/test.c
@@ -38,6 +38,7 @@ static void test_tok2str(void) {
 }
 
 int main(void) {
+  pcap_dhcp_mod_init(NULL);
   test_calc_vendor_specific_size();
   test_parse_vendor_specific_option_12();
   test_tok2str();

--- a/list/list.c
+++ b/list/list.c
@@ -1,4 +1,23 @@
 #include "list.h"
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void *(*list_malloc_hook)(size_t) = malloc;
+static void (*list_free_hook)(void *) = free;
+static void (*list_log_hook)(const char *, ...) = NULL;
+
+void list_mod_init(const list_mod_init_args_t *args) {
+  if (args) {
+    list_malloc_hook = args->malloc_fn ? args->malloc_fn : malloc;
+    list_free_hook = args->free_fn ? args->free_fn : free;
+    list_log_hook = args->log_fn;
+  } else {
+    list_malloc_hook = malloc;
+    list_free_hook = free;
+    list_log_hook = NULL;
+  }
+}
 
 int list_is_empty(const struct list_head *head) {
   return list_empty(head);

--- a/list/list.h
+++ b/list/list.h
@@ -4,6 +4,7 @@
 /* List and hash list stuff from kernel */
 
 #include <stdio.h>
+#include <stddef.h>
 
 #ifndef __LINUX_KERNEL_H
 #define __LINUX_KERNEL_H
@@ -202,4 +203,12 @@ static inline void list_splice_init(struct list_head *list, struct list_head *he
 
 int list_is_empty(const struct list_head *head);
 int list_count(const struct list_head *head);
+
+typedef struct {
+  void *(*malloc_fn)(size_t);
+  void (*free_fn)(void *);
+  void (*log_fn)(const char *, ...);
+} list_mod_init_args_t;
+
+void list_mod_init(const list_mod_init_args_t *args);
 #endif /* _LINUX_LIST_H_ */

--- a/list/test.c
+++ b/list/test.c
@@ -45,6 +45,7 @@ static void test_basic(void) {
 }
 
 int main(void) {
+  list_mod_init(NULL);
   test_basic();
   return 0;
 }

--- a/minheap/minheap.c
+++ b/minheap/minheap.c
@@ -5,6 +5,23 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
+
+static void *(*minheap_malloc_hook)(size_t) = malloc;
+static void (*minheap_free_hook)(void *) = free;
+static void (*minheap_log_hook)(const char *, ...) = NULL;
+
+void minheap_mod_init(const minheap_mod_init_args_t *args) {
+  if (args) {
+    minheap_malloc_hook = args->malloc_fn ? args->malloc_fn : malloc;
+    minheap_free_hook = args->free_fn ? args->free_fn : free;
+    minheap_log_hook = args->log_fn;
+  } else {
+    minheap_malloc_hook = malloc;
+    minheap_free_hook = free;
+    minheap_log_hook = NULL;
+  }
+}
 
 #ifdef TESTRUN
 // Переопределение malloc для тестирования

--- a/minheap/minheap.h
+++ b/minheap/minheap.h
@@ -80,4 +80,12 @@ bool mh_is_empty(minheap_t *minheap);
  */
 unsigned int mh_get_size(minheap_t *minheap);
 
+typedef struct {
+  void *(*malloc_fn)(size_t);
+  void (*free_fn)(void *);
+  void (*log_fn)(const char *, ...);
+} minheap_mod_init_args_t;
+
+void minheap_mod_init(const minheap_mod_init_args_t *args);
+
 #endif /* LIBMINHEAP_MINHEAP_H */

--- a/minheap/test.c
+++ b/minheap/test.c
@@ -651,6 +651,7 @@ void test_performance_vs_list() {
 }
 
 int main(void) {
+  minheap_mod_init(NULL);
 #ifdef DEBUG
   setup_syslog2("uevent_test", LOG_DEBUG, false);
 #else

--- a/netlink_arp_cache/libnlarpcache.c
+++ b/netlink_arp_cache/libnlarpcache.c
@@ -4,6 +4,26 @@
 
 #include "libnlarpcache.h"
 #include "../syslog2/syslog2.h"
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void *(*netlink_arp_cache_malloc_hook)(size_t) = malloc;
+static void (*netlink_arp_cache_free_hook)(void *) = free;
+static void (*netlink_arp_cache_log_hook)(const char *, ...) = NULL;
+
+void netlink_arp_cache_mod_init(
+    const netlink_arp_cache_mod_init_args_t *args) {
+  if (args) {
+    netlink_arp_cache_malloc_hook = args->malloc_fn ? args->malloc_fn : malloc;
+    netlink_arp_cache_free_hook = args->free_fn ? args->free_fn : free;
+    netlink_arp_cache_log_hook = args->log_fn;
+  } else {
+    netlink_arp_cache_malloc_hook = malloc;
+    netlink_arp_cache_free_hook = free;
+    netlink_arp_cache_log_hook = NULL;
+  }
+}
 
 void parse_rtattr(struct rtattr *tb[], int max, struct rtattr *rta, unsigned len) {
   /* loop over all rtattributes */

--- a/netlink_arp_cache/libnlarpcache.h
+++ b/netlink_arp_cache/libnlarpcache.h
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stddef.h>
 #include <errno.h>
 #include <string.h>
 #include <arpa/inet.h>
@@ -24,5 +25,13 @@ void parse_rtattr(struct rtattr *tb[], int max, struct rtattr *rta, unsigned len
 ssize_t send_recv(const void *send_buf, size_t send_buf_len, void **recv_buf);
 ssize_t get_arp_cache(void **buf_ptr);
 ssize_t parse_arp_cache(void *buf, ssize_t buf_size, arp_cache cache[]);
+
+typedef struct {
+  void *(*malloc_fn)(size_t);
+  void (*free_fn)(void *);
+  void (*log_fn)(const char *, ...);
+} netlink_arp_cache_mod_init_args_t;
+
+void netlink_arp_cache_mod_init(const netlink_arp_cache_mod_init_args_t *args);
 
 #endif /* _LIB_NL_ARP_CACHE */

--- a/netlink_arp_cache/test.c
+++ b/netlink_arp_cache/test.c
@@ -6,6 +6,7 @@
 #include <string.h>
 
 int main(void) {
+  netlink_arp_cache_mod_init(NULL);
   unsigned char buf[256];
 
   struct rtattr *rta1 = (struct rtattr *)buf;

--- a/netlink_getlink/libnl_getlink.h
+++ b/netlink_getlink/libnl_getlink.h
@@ -5,6 +5,7 @@
 #include <linux/rtnetlink.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h>
 
 #include <stdarg.h>      // va_list, va_start(), va_end()
 #include <stdio.h>       // printf()
@@ -45,5 +46,13 @@ typedef struct nl_req {
 int get_netdev(struct slist_head *list);
 netdev_item_t *ll_get_by_index(struct slist_head *list, int index);
 void free_netdev_list(struct slist_head *list);
+
+typedef struct {
+  void *(*malloc_fn)(size_t);
+  void (*free_fn)(void *);
+  void (*log_fn)(const char *, ...);
+} netlink_getlink_mod_init_args_t;
+
+void netlink_getlink_mod_init(const netlink_getlink_mod_init_args_t *args);
 
 #endif // NETLINK_GET_ADDR_LIBNL_GETLINK_H

--- a/netlink_getlink/test.c
+++ b/netlink_getlink/test.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 
 int main(void) {
+  netlink_getlink_mod_init(NULL);
   struct slist_head list;
   INIT_SLIST_HEAD(&list);
 

--- a/nlmon/nlmon.c
+++ b/nlmon/nlmon.c
@@ -9,6 +9,24 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+static void *(*nlmon_malloc_hook)(size_t) = malloc;
+static void (*nlmon_free_hook)(void *) = free;
+static void (*nlmon_log_hook)(const char *, ...) = NULL;
+
+void nlmon_mod_init(const nlmon_mod_init_args_t *args) {
+  if (args) {
+    nlmon_malloc_hook = args->malloc_fn ? args->malloc_fn : malloc;
+    nlmon_free_hook = args->free_fn ? args->free_fn : free;
+    nlmon_log_hook = args->log_fn;
+  } else {
+    nlmon_malloc_hook = malloc;
+    nlmon_free_hook = free;
+    nlmon_log_hook = NULL;
+  }
+}
 #include <sys/socket.h>
 #include <syslog.h>
 #include <unistd.h>

--- a/nlmon/nlmon.h
+++ b/nlmon/nlmon.h
@@ -44,4 +44,12 @@ void deinit_netlink_monitor(int fd);
 // Callback для обработки Netlink-событий
 void nl_handler_cb(uevent_t *ev, int fd, short events);
 
+typedef struct {
+  void *(*malloc_fn)(size_t);
+  void (*free_fn)(void *);
+  void (*log_fn)(const char *, ...);
+} nlmon_mod_init_args_t;
+
+void nlmon_mod_init(const nlmon_mod_init_args_t *args);
+
 #endif // NL_MON_H

--- a/nlmon/nlmon_test.c
+++ b/nlmon/nlmon_test.c
@@ -293,6 +293,7 @@ static void test_nl_handler_cb_multi_ifnames_events(void) {
 }
 
 int main(void) {
+  nlmon_mod_init(NULL);
   tu_init();
 
   test_init_netlink_monitor();

--- a/syslog2/syslog2.c
+++ b/syslog2/syslog2.c
@@ -9,6 +9,22 @@
 #include <syslog.h>
 #include <unistd.h>
 
+static void *(*syslog2_malloc_hook)(size_t) = malloc;
+static void (*syslog2_free_hook)(void *) = free;
+static void (*syslog2_log_hook)(const char *, ...) = NULL;
+
+void syslog2_mod_init(const syslog2_mod_init_args_t *args) {
+  if (args) {
+    syslog2_malloc_hook = args->malloc_fn ? args->malloc_fn : malloc;
+    syslog2_free_hook = args->free_fn ? args->free_fn : free;
+    syslog2_log_hook = args->log_fn;
+  } else {
+    syslog2_malloc_hook = malloc;
+    syslog2_free_hook = free;
+    syslog2_log_hook = NULL;
+  }
+}
+
 const char *last_function[MAX_THREADS] = {NULL};
 pid_t thread_ids[MAX_THREADS] = {0};
 pthread_t pthread_ids[MAX_THREADS] = {0};

--- a/syslog2/syslog2.h
+++ b/syslog2/syslog2.h
@@ -10,6 +10,7 @@
 #include <pthread.h>     //pthread_setname_np
 #include <stdarg.h>      // va_list, va_start(), va_end()
 #include <stdbool.h>     //bool type
+#include <stddef.h>
 #include <stdio.h>       // printf()
 #include <string.h>      //memcpy
 #include <sys/syscall.h> // SYS_gettid
@@ -80,6 +81,14 @@ void syslog2_(int pri, const char *func, const char *filename, int line, const c
 void syslog2_printf_(int pri, const char *func, const char *filename, int line, const char *fmt, ...);
 void debug(const char *fmt, ...);
 void print_last_functions();
+
+typedef struct {
+  void *(*malloc_fn)(size_t);
+  void (*free_fn)(void *);
+  void (*log_fn)(const char *, ...);
+} syslog2_mod_init_args_t;
+
+void syslog2_mod_init(const syslog2_mod_init_args_t *args);
 
 #define __FILENAME__ (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 : __FILE__)
 

--- a/syslog2/test.c
+++ b/syslog2/test.c
@@ -127,6 +127,7 @@ static void test_syslog_branch(void) {
 }
 
 int main(void) {
+  syslog2_mod_init(NULL);
   setup_syslog2("test_syslog2", LOG_DEBUG, false);
 
   syslog2(LOG_INFO, "Starting test");

--- a/timeutil/test.c
+++ b/timeutil/test.c
@@ -328,6 +328,7 @@ static void test_timezone_offset_fail(void) {
 }
 
 int main(void) {
+  timeutil_mod_init(NULL);
   tu_init();
 
   test_msleep_accuracy();

--- a/timeutil/timeutil.c
+++ b/timeutil/timeutil.c
@@ -3,6 +3,24 @@
 #include <stdatomic.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+static void *(*timeutil_malloc_hook)(size_t) = malloc;
+static void (*timeutil_free_hook)(void *) = free;
+static void (*timeutil_log_hook)(const char *, ...) = NULL;
+
+void timeutil_mod_init(const timeutil_mod_init_args_t *args) {
+  if (args) {
+    timeutil_malloc_hook = args->malloc_fn ? args->malloc_fn : malloc;
+    timeutil_free_hook = args->free_fn ? args->free_fn : free;
+    timeutil_log_hook = args->log_fn;
+  } else {
+    timeutil_malloc_hook = malloc;
+    timeutil_free_hook = free;
+    timeutil_log_hook = NULL;
+  }
+}
 
 static struct timespec offset_global_ts;
 static struct timespec pause_accum_global;

--- a/timeutil/timeutil.h
+++ b/timeutil/timeutil.h
@@ -12,6 +12,7 @@
 #include <pthread.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h>
 #include <time.h>
 
 #define NS_PER_USEC 1000U
@@ -39,6 +40,14 @@ int msleep(uint64_t ms);
 void atomic_ts_load(atomic_timespec_t *src, struct timespec *dest);
 void atomic_ts_store(atomic_timespec_t *dest, struct timespec *src);
 void atomic_ts_cpy(atomic_timespec_t *dest, atomic_timespec_t *src);
+
+typedef struct {
+  void *(*malloc_fn)(size_t);
+  void (*free_fn)(void *);
+  void (*log_fn)(const char *, ...);
+} timeutil_mod_init_args_t;
+
+void timeutil_mod_init(const timeutil_mod_init_args_t *args);
 
 static inline int tu_clock_gettime_monotonic_fast(struct timespec *ts) {
   return tu_clock_gettime_fast_internal(ts);

--- a/uevent/test.c
+++ b/uevent/test.c
@@ -1511,6 +1511,7 @@ void test_persist_and_self_adding_timer_with_workers() {
 }
 
 int main() {
+  uevent_mod_init(NULL);
   printf("Starting uevent library tests...\n\n");
 #ifdef DEBUG
   setup_syslog2("uevent_test", LOG_DEBUG, false);

--- a/uevent/uevent.c
+++ b/uevent/uevent.c
@@ -13,6 +13,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
 #include <sys/eventfd.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -25,6 +27,22 @@
 #include "uevent.h"
 #include "uevent_internal.h"
 #include "uevent_worker.h"
+
+static void *(*uevent_malloc_user)(size_t) = malloc;
+static void (*uevent_free_user)(void *) = free;
+static void (*uevent_log_hook_user)(const char *, ...) = NULL;
+
+void uevent_mod_init(const uevent_mod_init_args_t *args) {
+  if (args) {
+    uevent_malloc_user = args->malloc_fn ? args->malloc_fn : malloc;
+    uevent_free_user = args->free_fn ? args->free_fn : free;
+    uevent_log_hook_user = args->log_fn;
+  } else {
+    uevent_malloc_user = malloc;
+    uevent_free_user = free;
+    uevent_log_hook_user = NULL;
+  }
+}
 
 #define EPOLL_MAX_TIMEOUT_MS 60000U
 #define UEVENT_DEFAULT_WORKERS_NUM 6

--- a/uevent/uevent.h
+++ b/uevent/uevent.h
@@ -172,4 +172,12 @@ uint64_t get_current_time_ms(void);
 uev_t *uevent_try_ref(uev_t *uev); // atomic
 bool uevent_put(uev_t *uev);       // atomic
 
+typedef struct {
+  void *(*malloc_fn)(size_t);
+  void (*free_fn)(void *);
+  void (*log_fn)(const char *, ...);
+} uevent_mod_init_args_t;
+
+void uevent_mod_init(const uevent_mod_init_args_t *args);
+
 #endif /* LIBUEVENT_UEVENT_H */

--- a/uevent/uevent_worker.c
+++ b/uevent/uevent_worker.c
@@ -10,8 +10,26 @@
 
 #include <inttypes.h>
 #include <pthread.h>
-#include <stdatomic.h>
+#include <stdarg.h>
+#include <stdio.h>
 #include <stdlib.h>
+
+static void *(*uevent_worker_malloc_hook)(size_t) = malloc;
+static void (*uevent_worker_free_hook)(void *) = free;
+static void (*uevent_worker_log_hook)(const char *, ...) = NULL;
+
+void uevent_worker_mod_init(const uevent_mod_init_args_t *args) {
+  if (args) {
+    uevent_worker_malloc_hook = args->malloc_fn ? args->malloc_fn : malloc;
+    uevent_worker_free_hook = args->free_fn ? args->free_fn : free;
+    uevent_worker_log_hook = args->log_fn;
+  } else {
+    uevent_worker_malloc_hook = malloc;
+    uevent_worker_free_hook = free;
+    uevent_worker_log_hook = NULL;
+  }
+}
+#include <stdatomic.h>
 
 #define UEV_EXTRA_WORKER_TASKS 100
 #define UEV_MAX_WORKER_MULTIPLIER 8


### PR DESCRIPTION
## Summary
- add minimal `*_mod_init_args_t` structs and `*_mod_init` functions
- keep hooks for allocators and logging in each module
- initialize modules in tests via new init functions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686c05834a2c8330aad8b424b1ec2dc1