### PR TITLE
Add single test execution for timeutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ cd <module>
 make coverage
 ```
 
+The timeutil module also accepts a `TEST` variable so you can run a single test:
+
+```sh
+cd timeutil
+make test TEST=msleep_accuracy
+```
+
 The `uevent` module offers a `check` target which runs both regular and robust tests.
 
 A small `test_util.h` header at the repository root defines common macros for

--- a/timeutil/Makefile
+++ b/timeutil/Makefile
@@ -40,7 +40,7 @@ $(LIBNAME): $(OBJ)
 
 test: $(TEST_OBJ) $(LIBNAME)
 	$(CC) $(CFLAGS) $(TEST_OBJ) -o test $(LDFLAGS) $(LIBS)
-	./test
+	./test $(TEST)
 
 main: $(MAIN_OBJ) $(LIBNAME)
 	$(CC) $(CFLAGS) $(MAIN_OBJ) -o main $(LDFLAGS) $(LIBS)


### PR DESCRIPTION
## Summary
- allow running a specific test from the timeutil module
- expose the test name via `TEST` variable in the Makefile
- document this feature in README

## Testing
- `make test` (all modules)
- `make test TEST=msleep_accuracy` in timeutil


------
https://chatgpt.com/codex/tasks/task_e_686c16bb93d48330bbed7d9744868f83