### PR TITLE
Enable single test selection for timeutil

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ COV_DIRS := htable list minheap netlink_getlink nlmon syslog2 timeutil leak_dete
 test:
 	@set -e; for d in $(SUBDIRS); do \
 	printf "\n==> $$d\n"; \
-		if [ "$$d" = "uevent" ]; then \
-			$(MAKE) -C $$d check; \
-		else \
-			$(MAKE) -C $$d test; \
-		fi; \
+	if [ "$$d" = "uevent" ]; then \
+	$(MAKE) -C $$d check TEST="$(TEST)"; \
+	else \
+	$(MAKE) -C $$d test TEST="$(TEST)"; \
+	fi; \
 	done
 
 # Run coverage where supported

--- a/README.md
+++ b/README.md
@@ -86,3 +86,9 @@ The optional Makefile in the repository root aggregates common actions:
 - `make clean` – remove build artefacts in all modules.
 
 Use it as a convenience wrapper instead of invoking `make` in each subdirectory.
+
+You can pass a `TEST` variable to run a single test from the `timeutil` module:
+
+```sh
+make test TEST=msleep_accuracy
+```


### PR DESCRIPTION
## Summary
- allow passing TEST variable to the root Makefile so a single test can be executed in the timeutil module
- document the TEST variable usage

## Testing
- `make test`
- `make -C timeutil test TEST=msleep_accuracy`


------
https://chatgpt.com/codex/tasks/task_e_686c1b34d5ac8330a8285e69a7ff62a7