### PR TITLE
Add clang-tidy integration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: "-*,clang-analyzer-*,readability-*"
+WarningsAsErrors: ""

--- a/README.md
+++ b/README.md
@@ -86,3 +86,13 @@ The optional Makefile in the repository root aggregates common actions:
 - `make clean` – remove build artefacts in all modules.
 
 Use it as a convenience wrapper instead of invoking `make` in each subdirectory.
+
+## CI Script
+
+The `ci.sh` helper script runs `clang-tidy` over all `*.c` and `*.h` files and
+then executes the full test suite. Make sure `clang-tidy` is installed before
+invoking it:
+
+```sh
+./ci.sh
+```

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+clang_files=$(git ls-files '*.c' '*.h')
+if [ -n "$clang_files" ]; then
+  for f in $clang_files; do
+    echo "Running clang-tidy on $f"
+    clang-tidy -quiet "$f" --
+  done
+fi
+
+make test


### PR DESCRIPTION
## Summary
- add `.clang-tidy` config with minimal checks
- run clang-tidy from `ci.sh`
- document clang-tidy requirement in the root README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686c1bf348288330a3723c86a2a52144