### PR TITLE
Add timeutil performance comparison test

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ cd timeutil
 make test TEST=msleep_accuracy
 ```
 
+A dedicated performance test named `perf_custom_vs_system` compares the
+execution time of `tu_clock_gettime_monotonic_fast` with the standard
+`clock_gettime` implementation and prints absolute and relative results:
+
+```sh
+cd timeutil
+make test TEST=perf_custom_vs_system
+```
+
 The `uevent` module offers a `check` target which runs both regular and robust tests.
 
 A small `test_util.h` header at the repository root defines common macros for


### PR DESCRIPTION
## Summary
- add a performance test comparing `tu_clock_gettime_monotonic_fast` with `clock_gettime`
- document the new test in README

## Testing
- `make test TEST=perf_custom_vs_system` in timeutil
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686c1de560488330b9cb637b45b80c73