### PR TITLE
Add realtime clock_gettime perf test

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ make test TEST=msleep_accuracy
 ```
 
 A dedicated performance test named `perf_custom_vs_system` compares the
-execution time of `tu_clock_gettime_monotonic_fast` with the standard
-`clock_gettime` implementation and prints absolute and relative results:
+execution time of the fast helpers with the standard `clock_gettime`
+implementation for both monotonic and realtime clocks. The results are
+printed in absolute values and percentages:
 
 ```sh
 cd timeutil


### PR DESCRIPTION
## Summary
- extend timeutil performance test to measure realtime clock
- document new comparison in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686c20defef48330962e628d6fb23ee2