### PR TITLE
Remove TESTRUN conditionals from tests

### DIFF
--- a/minheap/minheap.c
+++ b/minheap/minheap.c
@@ -21,7 +21,6 @@ int minheap_mod_init(const minheap_mod_init_args_t *args) {
   return 0;
 }
 
-#ifdef TESTRUN
 // Переопределение malloc для тестирования
 malloc_func_t malloc_orig = malloc;
 malloc_func_t malloc_hook = malloc;
@@ -33,7 +32,6 @@ malloc_func_t malloc_hook = malloc;
 void *test_malloc_fail(size_t size) {
   return NULL;
 }
-#endif
 
 // Устанавливает индекс узла (idx + 1 для отличия от 0)
 void mh_map_set(minheap_t *minheap, minheap_node_t *node, int idx) {

--- a/minheap/minheap.h
+++ b/minheap/minheap.h
@@ -6,7 +6,6 @@
 #include <stdint.h>
 #include <time.h>
 
-#ifdef TESTRUN
 // --- Нужные функции и переменные для тестов ---
 typedef void *(*malloc_func_t)(size_t);
 extern malloc_func_t malloc_hook;
@@ -25,8 +24,6 @@ void *test_malloc_fail(size_t size);
   do {                         \
     malloc_hook = malloc_orig; \
   } while (0)
-
-#endif
 
 #ifndef container_of
 #define container_of(ptr, type, member)                \

--- a/minheap/test.c
+++ b/minheap/test.c
@@ -85,7 +85,6 @@ void *test_malloc_fail_second(size_t size) {
 }
 
 void test_create_malloc_fail() {
-#ifdef TESTRUN
   PRINT_TEST_START("Create heap with malloc failure (negative case)");
   SET_MALLOC(NULL);
   minheap_t *heap = mh_create(10);
@@ -100,7 +99,6 @@ void test_create_malloc_fail() {
   assert(heap == NULL && "minheap_create should fail if malloc fail on second call");
 
   PRINT_TEST_PASSED();
-#endif
 }
 
 void test_insert_null_node() {

--- a/netlink_arp_cache/test.c
+++ b/netlink_arp_cache/test.c
@@ -26,7 +26,6 @@ static int mock_time(struct timespec *ts) {
   return 0;
 }
 
-#ifdef TESTRUN
 int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
            struct timeval *timeout) {
   (void)nfds;
@@ -37,7 +36,6 @@ int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
   errno = EINTR;
   return -1;
 }
-#endif
 
 static void test_parse_rtattr(void) {
   nlarpcache_mod_init(&(netlink_arp_cache_mod_init_args_t){


### PR DESCRIPTION
## Summary
- simplify tests by removing `#ifdef TESTRUN` blocks
- always compile helper functions used for testing

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686ce2a259d883308b42155e176fbc02