### PR TITLE
Remove extraneous argument in syslog2 call

### DIFF
--- a/netlink_getlink/libnl_getlink.c
+++ b/netlink_getlink/libnl_getlink.c
@@ -262,7 +262,7 @@ static int parse_recv_chunk(void *buf, ssize_t len, struct slist_head *list) {
   for (nh = (struct nlmsghdr *)buf; NLMSG_OK(nh, len);
        nh = NLMSG_NEXT(nh, len)) {
     if (counter > 100) {
-      syslog2(LOG_ALERT, "counter %zu > 100", true, counter);
+      syslog2(LOG_ALERT, "counter %zu > 100", counter);
       break;
     }
 


### PR DESCRIPTION
## Summary
- fix a syslog2 call in netlink_getlink that was passing a stray boolean

## Testing
- `make test` (within netlink_getlink)

------
https://chatgpt.com/codex/tasks/task_e_686f2c887e7c8330ac40c1878d5257ab