### PR TITLE
Document injectable logger for netlink_getlink

### DIFF
--- a/netlink_getlink/libnl_getlink.h
+++ b/netlink_getlink/libnl_getlink.h
@@ -49,6 +49,8 @@ typedef struct nl_req {
 
 typedef void (*syslog2_fn_t)(int pri, const char *func, const char *file, int line, const char *fmt, bool nl, va_list ap);
 
+/* Allows callers to inject a custom logging routine so this module does not
+   depend directly on syslog2. */
 typedef struct netlink_getlink_mod_init_args_t {
   syslog2_fn_t syslog2_func;
 } netlink_getlink_mod_init_args_t;


### PR DESCRIPTION
## Summary
- clarify that users can supply their own logging routine when initializing `netlink_getlink`

## Testing
- `make clean && make test` in `netlink_getlink`

------
https://chatgpt.com/codex/tasks/task_e_686f2c8f7f5483308eb9d356869b7c01