### PR TITLE
Use pthread_once for netlink_getlink init

### DIFF
--- a/netlink_getlink/README.md
+++ b/netlink_getlink/README.md
@@ -17,8 +17,8 @@ run `./build/getlink_shared` and check
 leakcheck report `cat /tmp/leak_info.txt`
 
 ## Initialization
-Before using the library functions you may optionally call
-`netlink_getlink_mod_init()` to provide custom logging or time retrieval
-functions. Passing `NULL` sets defaults to use `syslog2` for logging and
-`clock_gettime` for time.
+Library initialization happens automatically on first use with
+`pthread_once`. You may optionally call `netlink_getlink_mod_init()`
+beforehand to supply a custom logging function. Passing `NULL` keeps the
+default `syslog2` logger.
 

--- a/netlink_getlink/libnl_getlink.c
+++ b/netlink_getlink/libnl_getlink.c
@@ -63,13 +63,7 @@ static pthread_once_t nlgl_once = PTHREAD_ONCE_INIT;
 
 int netlink_getlink_mod_init(const netlink_getlink_mod_init_args_t *args);
 
-static void nl_getlink_default_init(void) {
-  syslog2_func = syslog2_internal;
-}
-
-static void nl_getlink_init_marker(void) {
-  /* no-op */
-}
+static void nl_getlink_default_init(void) { syslog2_func = syslog2_internal; }
 
 #define parse_rtattr_nested(tb, max, rta) \
   (parse_rtattr((tb), (max), RTA_DATA(rta), RTA_PAYLOAD(rta)))
@@ -369,13 +363,11 @@ int get_netdev(struct slist_head *list) {
 }
 
 int netlink_getlink_mod_init(const netlink_getlink_mod_init_args_t *args) {
-  if (!args) {
-    syslog2_func = syslog2_internal;
-  } else {
-    if (args->syslog2_func) syslog2_func = args->syslog2_func;
-    else syslog2_func = syslog2_internal;
+  pthread_once(&nlgl_once, nl_getlink_default_init);
+
+  if (args && args->syslog2_func) {
+    syslog2_func = args->syslog2_func;
   }
 
-  pthread_once(&nlgl_once, nl_getlink_init_marker);
   return 0;
 }


### PR DESCRIPTION
## Summary
- use pthread_once for internal initialization
- call the pthread_once initializer from exported functions
- document the automatic initialization in netlink_getlink README

## Testing
- `make test` *(fails: missing malloc_hook symbol during minheap build)*

------
https://chatgpt.com/codex/tasks/task_e_686f2cad3b708330adcd1a712ac51805