### PR TITLE
Refactor list and htable modules

### DIFF
--- a/htable/Makefile
+++ b/htable/Makefile
@@ -1,55 +1,46 @@
-CC = gcc
-CFLAGS = -Wall -Wextra -O3 -Wno-unused-parameter -ffunction-sections -fdata-sections -ggdb
-AR = ar
-ARFLAGS = rcs
-LIBNAME = libhtable.a
-OBJ = htable.o
-TEST_OBJ = test.o
-MAIN_OBJ = main.o
-LDFLAGS = -L.
-LIBS = -lhtable
+NAME = htable
+CC ?= gcc
+CFLAGS_BASE = -Wall -Wextra -Werror -Wno-unused-parameter \
+              -O2 -g -fvisibility=hidden -fno-common -ffunction-sections -fdata-sections
+CFLAGS = $(CFLAGS_BASE) -fPIC
+LDFLAGS = -Wl,--gc-sections
+MODULES = ../list
+SRC = $(filter-out main.c test.c, $(wildcard *.c))
+HDR = $(wildcard *.h)
+OBJ_STATIC = $(SRC:.c=.o)
+OBJ_SHARED = $(SRC:.c=_shared.o)
+TARGET_LIB = lib$(NAME).a
+TARGET_SO = lib$(NAME).so
+TARGET_TEST = test
+TARGET_MAIN = main
 
-COV_CFLAGS = $(CFLAGS) -O0 -g -fprofile-arcs -ftest-coverage
-COV_LDFLAGS = $(LDFLAGS) -fprofile-arcs -ftest-coverage
+.PHONY: all clean $(MODULES)
 
-all: $(LIBNAME) main test
+all: $(MODULES) $(TARGET_LIB) $(TARGET_SO) $(TARGET_TEST) $(TARGET_MAIN)
 
-$(LIBNAME): $(OBJ)
-	$(AR) $(ARFLAGS) $(LIBNAME) $(OBJ)
+$(MODULES):
+	$(MAKE) -C $@
 
-htable.o: htable.c htable.h
-	$(CC) $(CFLAGS) -c htable.c
+$(TARGET_LIB): $(OBJ_STATIC)
+	ar rcs $@ $^
 
-main: $(MAIN_OBJ) $(LIBNAME)
-	$(CC) $(CFLAGS) $(MAIN_OBJ) -o main $(LDFLAGS) $(LIBS)
+$(TARGET_SO): $(OBJ_SHARED)
+	$(CC) $(CFLAGS) -shared -o $@ $(OBJ_SHARED) \
+	$(addprefix -L,$(MODULES)) $(addprefix -l,$(notdir $(MODULES))) $(LDFLAGS)
 
-test: $(TEST_OBJ) $(LIBNAME)
-	        $(CC) $(CFLAGS) $(TEST_OBJ) -o test $(LDFLAGS) $(LIBS)
-	        ./test $(TEST)
+$(TARGET_TEST): test.o $(TARGET_LIB)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
-main.o: main.c htable.h
-	$(CC) $(CFLAGS) -c main.c
+$(TARGET_MAIN): main.o $(TARGET_SO)
+	$(CC) $(CFLAGS) -o $@ $^ -L. -l$(NAME) \
+$(addprefix -L,$(MODULES)) $(addprefix -l,$(notdir $(MODULES))) $(LDFLAGS)
 
-test.o: test.c htable.h
-	$(CC) $(CFLAGS) -c test.c
+%.o: %.c $(HDR)
+	$(CC) $(CFLAGS) -c $< -o $@
 
-perf: test
-	@echo "Running valgrind callgrind profiler..."
-	valgrind --tool=callgrind --callgrind-out-file=callgrind.out ./test
-	callgrind_annotate --inclusive=yes --auto=yes callgrind.out
-
-leak: test
-	@echo "Running valgrind memcheck for memory leaks..."
-	valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes ./test
+%_shared.o: %.c $(HDR)
+	$(CC) $(CFLAGS) -DIS_DYNAMIC_LIB -c $< -o $@
 
 clean:
-	rm -f *.o *.gcov *.gcno *.gcda $(LIBNAME) main test callgrind.out
-
-coverage: clean
-	$(MAKE) CFLAGS="$(COV_CFLAGS)" LDFLAGS="$(COV_LDFLAGS)" LIBS="$(LIBS)" test
-	@echo "=== Coverage report (gcov): ==="
-	@gcov htable.c | grep -A10 "File 'htable.c'"
-	@echo "=== Coverage report (summary): ==="
-	@gcov -b htable.c | grep -E 'Lines executed|Branches executed'
-
-.PHONY: all clean perf coverage
+	rm -f $(OBJ_STATIC) $(OBJ_SHARED) *.o *.a *.so $(TARGET_TEST) $(TARGET_MAIN)
+	$(foreach mod,$(MODULES),$(MAKE) -C $(mod) clean;)

--- a/htable/htable.c
+++ b/htable/htable.c
@@ -3,21 +3,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <time.h>
 
-static void (*log_func)(int, const char *, ...) = NULL;
-static int (*realtime_func)(struct timespec *) = NULL;
-
-int htable_mod_init(const htable_mod_init_args_t *args) {
-  if (!args) {
-    log_func = NULL;
-    realtime_func = NULL;
-    return 0;
-  }
-  log_func = args->log;
-  realtime_func = args->get_time;
-  return 0;
-}
+/* Simple hash table without external dependencies. */
 
 // Хеш-функция по ключу
 static inline unsigned int htable_hash(uintptr_t key, size_t capacity) {

--- a/htable/htable.h
+++ b/htable/htable.h
@@ -4,8 +4,6 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <time.h>
-
 #include "../list/list.h" // Предполагаем, что list.h в родительском каталоге
 
 // Узел хэш-таблицы
@@ -58,11 +56,5 @@ void *htable_get(htable_t *ht, uintptr_t key);
  */
 void htable_del(htable_t *ht, uintptr_t key);
 
-typedef struct {
-  void (*log)(int, const char *, ...);
-  int (*get_time)(struct timespec *);
-} htable_mod_init_args_t;
-
-int htable_mod_init(const htable_mod_init_args_t *args);
 
 #endif // HTABLE_H

--- a/list/Makefile
+++ b/list/Makefile
@@ -1,55 +1,40 @@
-CC = gcc
-CFLAGS = -Wall -Wextra -O3 -Wno-unused-parameter -ffunction-sections -fdata-sections -ggdb
-AR = ar
-ARFLAGS = rcs
-LIBNAME = liblist.a
-OBJ = list.o
-TEST_OBJ = test.o
-MAIN_OBJ = main.o
-LDFLAGS = -L.
-LIBS = -llist
+NAME = list
+CC ?= gcc
+CFLAGS_BASE = -Wall -Wextra -Werror -Wno-unused-parameter \
+              -O2 -g -fvisibility=hidden -fno-common -ffunction-sections -fdata-sections
+CFLAGS = $(CFLAGS_BASE) -fPIC
+LDFLAGS = -Wl,--gc-sections
+MODULES =
+SRC = $(filter-out main.c test.c, $(wildcard *.c))
+HDR = $(wildcard *.h)
+OBJ_STATIC = $(SRC:.c=.o)
+OBJ_SHARED = $(SRC:.c=_shared.o)
+TARGET_LIB = lib$(NAME).a
+TARGET_SO = lib$(NAME).so
+TARGET_TEST = test
+TARGET_MAIN = main
 
-COV_CFLAGS = $(CFLAGS) -O0 -g -fprofile-arcs -ftest-coverage
-COV_LDFLAGS = $(LDFLAGS) -fprofile-arcs -ftest-coverage
+.PHONY: all clean
 
-all: $(LIBNAME) main test
+all: $(TARGET_LIB) $(TARGET_SO) $(TARGET_TEST) $(TARGET_MAIN)
 
-$(LIBNAME): $(OBJ)
-	$(AR) $(ARFLAGS) $(LIBNAME) $(OBJ)
+$(TARGET_LIB): $(OBJ_STATIC)
+	ar rcs $@ $^
 
-list.o: list.c list.h
-	$(CC) $(CFLAGS) -c list.c
+$(TARGET_SO): $(OBJ_SHARED)
+	$(CC) $(CFLAGS) -shared -o $@ $(OBJ_SHARED) $(LDFLAGS)
 
-main: $(MAIN_OBJ) $(LIBNAME)
-	$(CC) $(CFLAGS) $(MAIN_OBJ) -o main $(LDFLAGS) $(LIBS)
+$(TARGET_TEST): test.o $(TARGET_LIB)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
-test: $(TEST_OBJ) $(LIBNAME)
-	        $(CC) $(CFLAGS) $(TEST_OBJ) -o test $(LDFLAGS) $(LIBS)
-	        ./test $(TEST)
+$(TARGET_MAIN): main.o $(TARGET_SO)
+	$(CC) $(CFLAGS) -o $@ $^ -L. -l$(NAME) $(LDFLAGS)
 
-main.o: main.c list.h
-	$(CC) $(CFLAGS) -c main.c
+%.o: %.c $(HDR)
+	$(CC) $(CFLAGS) -c $< -o $@
 
-test.o: test.c list.h
-	$(CC) $(CFLAGS) -c test.c
-
-perf: test
-	@echo "Running valgrind callgrind profiler..."
-	valgrind --tool=callgrind --callgrind-out-file=callgrind.out ./test
-	callgrind_annotate --inclusive=yes --auto=yes callgrind.out | head -n60
-
-leak: test
-	@echo "Running valgrind memcheck for memory leaks..."
-	valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes ./test
+%_shared.o: %.c $(HDR)
+	$(CC) $(CFLAGS) -DIS_DYNAMIC_LIB -c $< -o $@
 
 clean:
-	rm -f *.o *.gcov *.gcno *.gcda $(LIBNAME) main test callgrind.out
-
-coverage: clean
-	$(MAKE) CFLAGS="$(COV_CFLAGS)" LDFLAGS="$(COV_LDFLAGS)" LIBS="$(LIBS)" test
-	@echo "=== Coverage report (gcov): ==="
-	@gcov list.c | grep -A10 "File 'list.c'"
-	@echo "=== Coverage report (summary): ==="
-	@gcov -b list.c | grep -E 'Lines executed|Branches executed'
-
-.PHONY: all clean perf leak coverage
+	rm -f $(OBJ_STATIC) $(OBJ_SHARED) *.o *.a *.so $(TARGET_TEST) $(TARGET_MAIN)

--- a/list/list.c
+++ b/list/list.c
@@ -1,19 +1,6 @@
 #include "list.h"
-#include <time.h>
 
-static void (*log_func)(int, const char *, ...) = NULL;
-static int (*realtime_func)(struct timespec *) = NULL;
-
-int list_mod_init(const list_mod_init_args_t *args) {
-  if (!args) {
-    log_func = NULL;
-    realtime_func = NULL;
-    return 0;
-  }
-  log_func = args->log;
-  realtime_func = args->get_time;
-  return 0;
-}
+/* The list helpers are simple wrappers over the Linux kernel macros. */
 
 int list_is_empty(const struct list_head *head) {
   return list_empty(head);

--- a/list/list.h
+++ b/list/list.h
@@ -4,7 +4,6 @@
 /* List and hash list stuff from kernel */
 
 #include <stdio.h>
-#include <time.h>
 
 #ifndef __LINUX_KERNEL_H
 #define __LINUX_KERNEL_H
@@ -203,11 +202,4 @@ static inline void list_splice_init(struct list_head *list, struct list_head *he
 
 int list_is_empty(const struct list_head *head);
 int list_count(const struct list_head *head);
-
-typedef struct {
-  void (*log)(int, const char *, ...);
-  int (*get_time)(struct timespec *);
-} list_mod_init_args_t;
-
-int list_mod_init(const list_mod_init_args_t *args);
 #endif /* _LINUX_LIST_H_ */


### PR DESCRIPTION
## Summary
- remove unused dependency injection from `list` and `htable`
- simplify both modules
- update Makefiles to match other modules

## Testing
- `cd list && make clean && make test`
- `./test`
- `cd ../htable && make clean && make test`
- `./test`


------
https://chatgpt.com/codex/tasks/task_e_6876265ba5d883308dddd4900345a907