### PR TITLE
Update READMEs for weak symbol approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,36 +17,18 @@ This repository contains several small C libraries and utilities. Each module li
 - **hashtable-linux-kernel** – Linux kernel inspired hash table experiments.
 - **leak_detector_c** – simple leak detection helper used by other modules.
 
-  Many networking helpers rely on the `syslog2` library for logging instead of
-  shipping their own implementations.
+Many modules embed tiny fallback versions of functions from `syslog2` and
+`timeutil`.  These fallbacks are declared with `__attribute__((weak))` so the
+real implementations seamlessly override them when available.  When a module is
+built as a library only strong symbols are emitted, keeping dependencies
+explicit.
 
-## Custom Initialization
+## Weak symbol fallbacks
 
-Each module exposes a `*_mod_init` function that accepts an optional
-`mod_init_args_t` structure. Use these hooks to override logging and timing
-callbacks before calling any other APIs. Modules fall back to the default
-implementations (such as `syslog()` and `clock_gettime()`) when the argument is
-`NULL` or when individual fields are unset.
-
-Example initialization order:
-
-```c
-mod_init_args_t args = {
-  .log = my_log_function,
-  .get_time = my_get_time,
-};
-
-syslog2_mod_init(&(syslog2_mod_init_args_t){
-  .log = args.log,
-  .get_time = args.get_time,
-});
-
-timeutil_mod_init(&(timeutil_mod_init_args_t){
-  .get_time = args.get_time,
-});
-
-/* initialize other modules here */
-```
+The previous `*_mod_init` entry points were removed.  To customize a module you
+now provide your own implementations of the weak symbols it uses.  Linking the
+module together with `syslog2` or any other dependency automatically replaces
+the stubs shipped in the source.
 
 ## Running Tests
 

--- a/netlink_arp_cache/README.md
+++ b/netlink_arp_cache/README.md
@@ -1,15 +1,11 @@
 # arp cache getter via netlink kernel socket
 No dependencies program.
 
-### Initialization
+### Customization
 
-Use `nlarpcache_mod_init()` to override logging or time callbacks:
-
-```c
-nlarpcache_mod_init(&(netlink_arp_cache_mod_init_args_t){
-  .log = custom_log,
-  .get_time = custom_time});
-```
+Logging and timing helpers are provided via weak fallback functions such as
+`syslog2_` and `get_current_time_ms`.  Linking with the `syslog2` and
+`timeutil` modules or supplying your own implementations overrides these stubs.
 
 ## Howto build
 ```

--- a/netlink_getlink/README.md
+++ b/netlink_getlink/README.md
@@ -16,21 +16,10 @@ or make with leakcheck `make LEAKCHECK=1`
 run `./build/getlink_shared` and check
 leakcheck report `cat /tmp/leak_info.txt`
 
-## Initialization
-Before using the library functions you may call `netlink_getlink_mod_init()`
-to inject a custom logger. The function accepts a pointer to
-`netlink_getlink_mod_init_args_t` with a single field `syslog2_func`.  Passing
-`NULL` uses the default `syslog2` logger.
+## Customizing logging
 
-```c
-static void my_logger(int pri, const char *func, const char *file,
-                      int line, const char *fmt, bool nl, va_list ap) {
-  vfprintf(stderr, fmt, ap);
-  if (nl) fprintf(stderr, "\n");
-}
-
-netlink_getlink_mod_init(&(netlink_getlink_mod_init_args_t){
-  .syslog2_func = my_logger,
-});
-```
+The source includes a weak fallback implementation of `syslog2_`.  When linked
+with the `syslog2` module or with your own `syslog2_` function, the fallback is
+automatically replaced.  This keeps the library free of direct dependencies
+while still allowing flexible log routing.
 


### PR DESCRIPTION
## Summary
- document new weak symbol fallback approach in root README
- update netlink_getlink README for logger customization via weak symbols
- update netlink_arp_cache README for weak symbol customization

## Testing
- `make test` *(fails: ignoring return value of 'write')*

------
https://chatgpt.com/codex/tasks/task_e_6877965e19888330958027af4f16bcf5