### PR TITLE
Add libpcap DHCP capture module to build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-SUBDIRS := htable list minheap netlink_getlink nlmon syslog2 timeutil uevent leak_detector_c udeque hashtable-linux-kernel
-COV_DIRS := htable list minheap netlink_getlink nlmon syslog2 timeutil leak_detector_c udeque hashtable-linux-kernel
+SUBDIRS := htable list minheap netlink_getlink nlmon syslog2 timeutil uevent \
+  leak_detector_c udeque hashtable-linux-kernel libpcap-dhcp-capture
+COV_DIRS := htable list minheap netlink_getlink nlmon syslog2 timeutil \
+  leak_detector_c udeque hashtable-linux-kernel libpcap-dhcp-capture
 
 .PHONY: test coverage clean
 

--- a/libpcap-dhcp-capture/Makefile
+++ b/libpcap-dhcp-capture/Makefile
@@ -19,6 +19,7 @@ TARGET_LIB = lib$(NAME).a
 TARGET_SO  = lib$(NAME).so
 TARGET_TEST = test
 TARGET_MAIN = main
+TEST_BINS = test
 
 .PHONY: run all clean perf leak coverage $(MODULES)
 
@@ -39,8 +40,9 @@ $(TARGET_SO): $(OBJ_SHARED) $(MODULES)
 	$(addprefix -l,$(EXTRA_LIBS)) $(LDFLAGS)
 
 # test binary (static)
-$(TARGET_TEST): test.o $(TARGET_LIB)
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) \
+$(TARGET_TEST): test.o $(TARGET_LIB) $(TEST_MODULES)
+	$(CC) $(CFLAGS) -o $@ test.o $(TARGET_LIB) \
+	$(addprefix $(addsuffix /lib,$(notdir $(TEST_MODULES))).a,$(TEST_MODULES)) \
 	$(addprefix -l,$(EXTRA_LIBS)) $(LDFLAGS)
 	./test
 
@@ -78,11 +80,18 @@ leak: $(TARGET_TEST)
 
 # ------------------ покрытие ------------------
 
-COV_CFLAGS = --coverage -O0 -g
+COV_CFLAGS = --coverage -O0 -g -fPIC
 COV_LDFLAGS = --coverage
+COV_SRCS = $(SRC)
+
 coverage: clean
-	$(MAKE) CFLAGS="$(COV_CFLAGS)" LDFLAGS="$(COV_LDFLAGS)" LIBS="$(LIBS)" $(TARGET_TEST)
+	$(MAKE) CFLAGS="$(COV_CFLAGS)" LDFLAGS="$(COV_LDFLAGS)" $(TEST_BINS)
+	@for t in $(TEST_BINS); do ./$$t || exit 1; done
 	@echo "=== Coverage report (gcov): ==="
-	@gcov minheap.c | grep -A10 "File 'minheap.c'"
+	@for f in $(COV_SRCS); do \
+	        gcov "$$f" | grep -A10 "File '$$f'"; \
+	done
 	@echo "=== Coverage report (summary): ==="
-	@gcov -b minheap.c | grep -E 'Lines executed|Branches executed'
+	@for f in $(COV_SRCS); do \
+	        gcov -b "$$f" | grep -E 'Lines executed|Branches executed'; \
+	done

--- a/nlmon/nlmon.c
+++ b/nlmon/nlmon.c
@@ -40,7 +40,8 @@ __attribute__((weak)) void syslog2_(int pri, const char *func, const char *file,
   if (len >= (int)sz) len = sz - 1;
   if (nl && len < (int)sz - 1) buf[len++] = '\n';
 
-  write(STDOUT_FILENO, buf, len);
+  ssize_t ret = write(STDOUT_FILENO, buf, len);
+  (void)ret;
 }
 #endif // IS_DYNAMIC_LIB
 


### PR DESCRIPTION
## Summary
- add libpcap-dhcp-capture module to top-level build and coverage lists
- refactor libpcap-dhcp-capture Makefile to mirror minheap structure
- fix nlmon logging helper to handle write return value

## Testing
- `make -C libpcap-dhcp-capture all`
- `make -C libpcap-dhcp-capture test`
- `make -C libpcap-dhcp-capture coverage`
- `make -C libpcap-dhcp-capture clean`


------
https://chatgpt.com/codex/tasks/task_e_689ce464702483308a061e2e9474920b