### PR TITLE
netlink_getlink: add multithread stress test

### DIFF
--- a/netlink_getlink/Makefile
+++ b/netlink_getlink/Makefile
@@ -2,12 +2,13 @@ NAME = netlink_getlink
 CC ?= gcc
 CFLAGS_BASE = -Wall -Wextra -Werror -Wno-unused-parameter -O2 -g -fvisibility=hidden -fno-common -ffunction-sections -fdata-sections
 CFLAGS = $(CFLAGS_BASE) -fPIC
+CFLAGS += -pthread
 LDFLAGS = -Wl,--gc-sections
 
 # зависимости
 MODULES = ../timeutil ../syslog2
 
-EXTRA_LIBS = 
+EXTRA_LIBS = pthread
 
 SRC = $(filter-out main.c test.c, $(wildcard *.c))
 HDR = $(wildcard *.h)

--- a/netlink_getlink/test.c
+++ b/netlink_getlink/test.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <unistd.h>
+#include <pthread.h>
 
 static void test_get_netdev_list(void) {
   struct slist_head list;
@@ -45,10 +46,105 @@ static void test_default_logger_stdout(void) {
   PRINT_TEST_PASSED();
 }
 
+static volatile int stress_stop;
+
+static void *recv_worker(void *arg) {
+  (void)arg;
+  while (!stress_stop) {
+    struct slist_head list;
+    INIT_SLIST_HEAD(&list);
+    get_netdev(&list);
+    free_netdev_list(&list);
+  }
+  return NULL;
+}
+
+static void *if_worker(void *arg) {
+  int id = (int)(intptr_t)arg;
+  char br[32];
+  char veth0[32];
+  char veth1[32];
+  char cmd[128];
+  snprintf(br, sizeof(br), "brstress%d", id);
+  snprintf(veth0, sizeof(veth0), "veths%da", id);
+  snprintf(veth1, sizeof(veth1), "veths%db", id);
+  int r;
+  while (!stress_stop) {
+    switch (rand() % 4) {
+    case 0:
+      snprintf(cmd, sizeof(cmd),
+               "ip link add %s type bridge >/dev/null 2>&1", br);
+      r = system(cmd);
+      (void)r;
+      break;
+    case 1:
+      snprintf(cmd, sizeof(cmd), "ip link del %s >/dev/null 2>&1", br);
+      r = system(cmd);
+      (void)r;
+      break;
+    case 2:
+      snprintf(cmd, sizeof(cmd),
+               "ip link add %s type veth peer name %s >/dev/null 2>&1",
+               veth0, veth1);
+      r = system(cmd);
+      (void)r;
+      break;
+    default:
+      snprintf(cmd, sizeof(cmd), "ip link del %s >/dev/null 2>&1", veth0);
+      r = system(cmd);
+      (void)r;
+      snprintf(cmd, sizeof(cmd), "ip link del %s >/dev/null 2>&1", veth1);
+      r = system(cmd);
+      (void)r;
+      break;
+    }
+  }
+  snprintf(cmd, sizeof(cmd), "ip link del %s >/dev/null 2>&1", br);
+  r = system(cmd);
+  (void)r;
+  snprintf(cmd, sizeof(cmd), "ip link del %s >/dev/null 2>&1", veth0);
+  r = system(cmd);
+  (void)r;
+  snprintf(cmd, sizeof(cmd), "ip link del %s >/dev/null 2>&1", veth1);
+  r = system(cmd);
+  (void)r;
+  return NULL;
+}
+
+static void test_stress_recv_msg_chunk(void) {
+  int ret = system("ip link add __stress_dummy0 type dummy >/dev/null 2>&1");
+  if (ret != 0) {
+    PRINT_TEST_INFO("stress test skipped: requires NET_ADMIN");
+    PRINT_TEST_PASSED();
+    return;
+  }
+  ret = system("ip link del __stress_dummy0 >/dev/null 2>&1");
+  (void)ret;
+
+  stress_stop = 0;
+  srand(time(NULL));
+  const int recv_cnt = 4;
+  const int if_cnt = 2;
+  pthread_t recv_threads[recv_cnt];
+  pthread_t mod_threads[if_cnt];
+  for (int i = 0; i < recv_cnt; i++)
+    pthread_create(&recv_threads[i], NULL, recv_worker, NULL);
+  for (int i = 0; i < if_cnt; i++)
+    pthread_create(&mod_threads[i], NULL, if_worker, (void *)(intptr_t)i);
+  sleep(2);
+  stress_stop = 1;
+  for (int i = 0; i < recv_cnt; i++)
+    pthread_join(recv_threads[i], NULL);
+  for (int i = 0; i < if_cnt; i++)
+    pthread_join(mod_threads[i], NULL);
+  PRINT_TEST_PASSED();
+}
+
 int main(int argc, char **argv) {
   struct test_entry tests[] = {
       {"get_netdev_list", test_get_netdev_list},
-      {"default_logger_stdout", test_default_logger_stdout}};
+      {"default_logger_stdout", test_default_logger_stdout},
+      {"stress_recv_msg_chunk", test_stress_recv_msg_chunk}};
   int rc = run_named_test(argc > 1 ? argv[1] : NULL, tests, ARRAY_SIZE(tests));
   if (!rc && argc == 1)
     printf(KGRN "====== All netlink_getlink tests passed! ======\n" KNRM);


### PR DESCRIPTION
## Summary
- add stress test simulating concurrent recv_msg_chunk calls with interface churn
- build netlink_getlink tests with pthread support

## Testing
- `cd netlink_getlink && make test`


------
https://chatgpt.com/codex/tasks/task_e_689d0043177483308be5f7bb8c0430cb